### PR TITLE
#28: When flattening resources from a bundle, if the fullUrl specifie…

### DIFF
--- a/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/DirectoryBundler.java
+++ b/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/DirectoryBundler.java
@@ -179,6 +179,18 @@ public class DirectoryBundler {
     
     }
 
+    private String stripUrnScheme(String uri) {
+        if (uri.startsWith("urn:uuid:")) {
+            return uri.substring(9);
+        }
+        else if (uri.startsWith("urn:oid:")) {
+            return uri.substring(8);
+        }
+        else {
+            return uri;
+        }
+    }
+
     private List<IBaseResource> flatten(FhirContext fhirContext, IBaseBundle bundle) {
         List<IBaseResource> resources = new ArrayList<>();
 
@@ -188,6 +200,9 @@ public class DirectoryBundler {
                 List<IBaseResource> innerResources = flatten(fhirContext, (IBaseBundle) r);
                 resources.addAll(innerResources);
             } else {
+                if (r.getIdElement().getIdPart().startsWith("urn:")) {
+                    r.setId(stripUrnScheme(r.getIdElement().getIdPart()));
+                }
                 resources.add(r);
             }
         }


### PR DESCRIPTION
…s a urn scheme, reset the loaded resource id to remove it.