### PR TITLE
Implement support for supplemental data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target
+test-output
+bin/
 
 .classpath
 .project

--- a/evaluator.measure-hapi/pom.xml
+++ b/evaluator.measure-hapi/pom.xml
@@ -30,5 +30,22 @@
             <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>engine.fhir</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>evaluator.cql2elm</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>evaluator.fhir</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/r4/R4MeasureEvaluation.java
+++ b/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/r4/R4MeasureEvaluation.java
@@ -1,40 +1,57 @@
 package org.opencds.cqf.cql.evaluator.measure.r4;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.ListResource;
+import org.hl7.fhir.r4.model.ListResource.ListEntryComponent;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.Measure.MeasureGroupComponent;
 import org.hl7.fhir.r4.model.Measure.MeasureGroupPopulationComponent;
+import org.hl7.fhir.r4.model.Measure.MeasureSupplementalDataComponent;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.MeasureReport.MeasureReportGroupComponent;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
 import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasureEvaluation;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasureInfo;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasurePopulationType;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasureReportType;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasureScoring;
-import org.opencds.cqf.cql.engine.runtime.Interval;
 
 /**
  * Implementation of MeasureEvaluation on top of HAPI FHIR R4 structures.
  */
-public class R4MeasureEvaluation<RT, ST extends RT> extends
-        MeasureEvaluation<IBase, Measure, MeasureGroupComponent, MeasureGroupPopulationComponent, MeasureReport, MeasureReportGroupComponent, MeasureReport.MeasureReportGroupPopulationComponent, RT, ST> {
+public class R4MeasureEvaluation<ST extends DomainResource> extends
+        MeasureEvaluation<IBase, Measure, MeasureGroupComponent, MeasureGroupPopulationComponent, MeasureSupplementalDataComponent,
+        MeasureReport, MeasureReportGroupComponent, MeasureReport.MeasureReportGroupPopulationComponent,
+        Coding, Extension, Reference, ListResource, ListResource.ListEntryComponent, DomainResource, ST> {
 
     public R4MeasureEvaluation(Context context, Measure measure, Interval measurementPeriod, String packageName,
-            Function<RT, String> getId, String patientOrPractitionerId) {
+            Function<DomainResource, String> getId, String patientOrPractitionerId) {
         super(context, measure, measurementPeriod, packageName, getId, patientOrPractitionerId);
     }
 
     public R4MeasureEvaluation(Context context, Measure measure, Interval measurementPeriod, String packageName,
-    Function<RT, String> getId) {
+            Function<DomainResource, String> getId) {
         super(context, measure, measurementPeriod, packageName, getId);
     }
 
@@ -105,10 +122,24 @@ public class R4MeasureEvaluation<RT, ST extends RT> extends
             report.setSubject(new Reference(this.getId.apply(subjects.get(0))));
         }
 
-        report.setPeriod(
-            new Period()
+        Period period = null;
+        if( measurementPeriod.getStart() instanceof DateTime ) {
+            DateTime dtStart = (DateTime)measurementPeriod.getStart();
+            DateTime dtEnd = (DateTime)measurementPeriod.getEnd();
+            
+            period = new Period()
+                    .setStart(dtStart.toJavaDate())
+                    .setEnd(dtEnd.toJavaDate());
+            
+        } else if( measurementPeriod.getStart() instanceof Date ) {
+            period = new Period()
                     .setStart((Date) measurementPeriod.getStart())
-                    .setEnd((Date) measurementPeriod.getEnd()));
+                    .setEnd((Date)measurementPeriod.getEnd());
+        } else { 
+            throw new IllegalArgumentException("Measurement period should be an interval of CQL DateTime or Java Date objects");
+        }
+        
+        report.setPeriod(period);
 
         return report;
     }
@@ -129,5 +160,170 @@ public class R4MeasureEvaluation<RT, ST extends RT> extends
     @Override
     protected void addReportGroup(MeasureReport report, MeasureReportGroupComponent group) {
         report.addGroup(group);
+    }
+    
+    @Override
+    protected List<MeasureSupplementalDataComponent> getSupplementalData(Measure measure) {
+        return measure.getSupplementalData();
+    }
+
+    @Override
+    protected String getSDEExpression(MeasureSupplementalDataComponent sdeItem) {
+        String result = null; 
+        if( sdeItem.getCriteria() != null ) {
+            result = sdeItem.getCriteria().getExpression();
+        }
+        return result;
+    }
+
+    @Override
+    protected Coding getSDECoding(MeasureSupplementalDataComponent sdeItem) {
+        Coding result = null;
+        if( sdeItem.getCode() != null && sdeItem.getCode().getCodingFirstRep() != null ) {
+            result = sdeItem.getCode().getCodingFirstRep();
+        }
+        return result;
+    }
+    
+    @Override
+    protected String getCodingCode(Coding coding) { 
+        String result = null;
+        if( coding != null ) {
+            result = coding.getCode();
+        }
+        return result;
+    }
+
+    @Override
+    protected boolean isCoding(Object obj) {
+        return obj instanceof Coding;
+    }
+
+    @Override
+    protected DomainResource createPopulationObservation(Measure measure, String populationId, Coding valueCoding, Integer sdeAccumulatorValue) {
+
+        Observation obs = createObservation(measure,populationId);
+        
+        CodeableConcept obsCodeableConcept = new CodeableConcept();
+        obsCodeableConcept.setCoding(Collections.singletonList(valueCoding));
+        
+        obs.setCode(obsCodeableConcept);
+        obs.setValue(new IntegerType(sdeAccumulatorValue));
+        
+        
+        return obs;
+    }
+    
+    @Override
+    protected DomainResource createPatientObservation(Measure measure, String populationId, Coding valueCoding) {
+
+        Observation obs = createObservation(measure,populationId);
+        
+        CodeableConcept codeCodeableConcept = new CodeableConcept().setText(populationId);
+        obs.setCode( codeCodeableConcept );
+        
+        CodeableConcept valueCodeableConcept = new CodeableConcept();
+        valueCodeableConcept.setCoding(Collections.singletonList(valueCoding));
+        obs.setValue(valueCodeableConcept);
+        
+        return obs;
+    }
+    
+    protected Observation createObservation(Measure measure, String populationId) {
+        MeasureInfo measureInfo = new MeasureInfo()
+                .withMeasure(MeasureInfo.MEASURE_PREFIX + measure.getIdElement().getIdPart())
+                .withPopulationId(populationId);
+        
+        Observation obs = new Observation();
+        obs.setStatus(Observation.ObservationStatus.FINAL);
+        obs.setId(UUID.randomUUID().toString());
+        obs.addExtension( createMeasureInfoExtension(measureInfo) );
+        
+        return obs;
+    }
+    
+    protected Extension createMeasureInfoExtension(MeasureInfo measureInfo) {
+        
+        Extension extExtMeasure = new Extension().setUrl(MeasureInfo.MEASURE)
+                .setValue(new CanonicalType(measureInfo.getMeasure()));
+        
+        Extension extExtPop = new Extension().setUrl(MeasureInfo.POPULATION_ID)
+                .setValue(new StringType(measureInfo.getPopulationId()));
+        
+        Extension obsExtension = new Extension().setUrl(MeasureInfo.EXT_URL);
+        obsExtension.addExtension(extExtMeasure);
+        obsExtension.addExtension(extExtPop);
+        
+        return obsExtension;
+    }
+
+    @Override
+    protected void addEvaluatedResource(MeasureReport report, DomainResource resource) {
+        report.addEvaluatedResource( new Reference("#" + this.getId.apply(resource)) );
+    }
+
+    @Override
+    protected void addContained(MeasureReport report, DomainResource resource) {
+        report.addContained((Resource)resource);
+    }
+
+    @Override
+    protected Coding createCoding(String text) {
+        return new Coding().setCode(text);
+    }
+
+    @Override
+    protected Coding getExtensionCoding(ST patient, String coreCategory, String sdeCode) {
+        Coding valueCoding = new Coding();
+        
+        patient.getExtension().forEach((ptExt) -> {
+            if (ptExt.getUrl().contains(coreCategory)) {
+                Coding extCoding = (Coding) ptExt.getExtension().get(0).getValue();
+                String extCode = getCodingCode(extCoding);
+                if (extCode.equalsIgnoreCase(sdeCode)) {
+                    valueCoding.setSystem(extCoding.getSystem());
+                    valueCoding.setCode(extCoding.getCode());
+                    valueCoding.setDisplay(extCoding.getDisplay());
+                }
+            }
+        });
+        
+        return valueCoding;
+    }
+
+    @Override
+    protected Extension createCodingExtension(String url, String codeSystem, String code) {
+        Extension ext = new Extension().setUrl(url);
+        Coding coding = new Coding().setSystem(codeSystem).setCode(code);
+        ext.setValue(coding);
+        return ext;
+    }
+
+    @Override
+    protected Reference createReference(String resourceId) {
+        return new Reference(resourceId);
+    }
+
+    @Override
+    protected ListResource createListResource(Collection<ListEntryComponent> entries) {
+        ListResource resource = new ListResource();
+        resource.setId(UUID.randomUUID().toString());
+        resource.getEntry().addAll(entries);
+        return resource;
+    }
+
+    @Override
+    protected ListEntryComponent createListEntry(Reference reference) {
+        return new ListEntryComponent().setItem(reference);
+    }
+
+    @Override
+    protected void addExtension(Reference reference, Extension extension) {
+        reference.addExtension(extension);
+    }
+
+    @Override
+    protected void setEvaluatedResources(MeasureReport report, Collection<Reference> evaluatedResources) {
+        report.getEvaluatedResource().addAll(evaluatedResources);
     }
 }

--- a/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/stu3/Stu3MeasureEvaluation.java
+++ b/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/stu3/Stu3MeasureEvaluation.java
@@ -1,39 +1,53 @@
 package org.opencds.cqf.cql.evaluator.measure.stu3;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.IntegerType;
 import org.hl7.fhir.dstu3.model.ListResource;
+import org.hl7.fhir.dstu3.model.ListResource.ListEntryComponent;
 import org.hl7.fhir.dstu3.model.Measure;
 import org.hl7.fhir.dstu3.model.Measure.MeasureGroupComponent;
 import org.hl7.fhir.dstu3.model.Measure.MeasureGroupPopulationComponent;
+import org.hl7.fhir.dstu3.model.Measure.MeasureSupplementalDataComponent;
 import org.hl7.fhir.dstu3.model.MeasureReport;
 import org.hl7.fhir.dstu3.model.MeasureReport.MeasureReportGroupComponent;
+import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasureEvaluation;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasureInfo;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasurePopulationType;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasureReportType;
 import org.opencds.cqf.cql.evaluator.measure.common.MeasureScoring;
-import org.opencds.cqf.cql.engine.runtime.Interval;
 
 /**
  * Implementation of MeasureEvaluation on top of HAPI FHIR STU3 structures.
  */
-public class Stu3MeasureEvaluation<RT, ST extends RT> extends
-        MeasureEvaluation<IBase, Measure, MeasureGroupComponent, MeasureGroupPopulationComponent, MeasureReport, MeasureReportGroupComponent, MeasureReport.MeasureReportGroupPopulationComponent, RT, ST> {
+public class Stu3MeasureEvaluation<ST extends DomainResource> extends
+        MeasureEvaluation<IBase, Measure, MeasureGroupComponent, MeasureGroupPopulationComponent, Measure.MeasureSupplementalDataComponent, MeasureReport, MeasureReportGroupComponent, MeasureReport.MeasureReportGroupPopulationComponent, Coding, Extension, Reference, ListResource, ListResource.ListEntryComponent, DomainResource, ST> {
 
     public Stu3MeasureEvaluation(Context context, Measure measure, Interval measurementPeriod, String packageName,
-            Function<RT, String> getId, String patientOrPractitionerId) {
+            Function<DomainResource, String> getId, String patientOrPractitionerId) {
         super(context, measure, measurementPeriod, packageName, getId, patientOrPractitionerId);
     }
 
     public Stu3MeasureEvaluation(Context context, Measure measure, Interval measurementPeriod, String packageName,
-    Function<RT, String> getId) {
+    Function<DomainResource, String> getId) {
         super(context, measure, measurementPeriod, packageName, getId);
     }
 
@@ -104,10 +118,24 @@ public class Stu3MeasureEvaluation<RT, ST extends RT> extends
             report.setPatient(new Reference(this.getId.apply(subjects.get(0))));
         }
 
-        report.setPeriod(
-            new Period()
+        Period period = null;
+        if( measurementPeriod.getStart() instanceof DateTime ) {
+            DateTime dtStart = (DateTime)measurementPeriod.getStart();
+            DateTime dtEnd = (DateTime)measurementPeriod.getEnd();
+            
+            period = new Period()
+                    .setStart(dtStart.toJavaDate())
+                    .setEnd(dtEnd.toJavaDate());
+            
+        } else if( measurementPeriod.getStart() instanceof Date ) {
+            period = new Period()
                     .setStart((Date) measurementPeriod.getStart())
-                    .setEnd((Date) measurementPeriod.getEnd()));
+                    .setEnd((Date)measurementPeriod.getEnd());
+        } else { 
+            throw new IllegalArgumentException("Measurement period should be an interval of CQL DateTime or Java Date objects");
+        }
+        
+        report.setPeriod(period);
 
         return report;
     }
@@ -128,6 +156,207 @@ public class Stu3MeasureEvaluation<RT, ST extends RT> extends
     @Override
     protected void addReportGroup(MeasureReport report, MeasureReportGroupComponent group) {
         report.addGroup(group);
+    }
+    
+    @Override
+    protected List<MeasureSupplementalDataComponent> getSupplementalData(Measure measure) {
+        return measure.getSupplementalData();
+    }
+
+    @Override
+    protected String getSDEExpression(MeasureSupplementalDataComponent sdeItem) {
+        String result = null; 
+        if( sdeItem.getCriteria() != null ) {
+            result = sdeItem.getCriteria();
+        }
+        return result;
+    }
+
+    @Override
+    protected Coding getSDECoding(MeasureSupplementalDataComponent sdeItem) {
+        Coding result = null;
+        if( sdeItem.getIdentifier() != null ) {
+            // TODO - Is this correct? There isn't an obvious code in STU3
+            result = new Coding().setCode(sdeItem.getIdentifier().getValue());
+        }
+        return result;
+    }
+
+    @Override
+    protected boolean isCoding(Object obj) {
+        return obj instanceof Coding;
+    }
+
+    @Override
+    protected Coding createCoding(String text) {
+        return new Coding().setCode(text);
+    }
+
+    @Override
+    protected String getCodingCode(Coding coding) {
+        return coding.getCode();
+    }
+
+    @Override
+    protected DomainResource createPatientObservation(Measure measure, String populationId, Coding coding) {
+        Observation obs = createObservation(measure,populationId);
+        
+        CodeableConcept codeCodeableConcept = new CodeableConcept().setText(populationId);
+        obs.setCode( codeCodeableConcept );
+        
+        CodeableConcept valueCodeableConcept = new CodeableConcept();
+        valueCodeableConcept.setCoding(Collections.singletonList(coding));
+        obs.setValue(valueCodeableConcept);
+        
+        return obs;
+
+    }
+
+    @Override
+    protected DomainResource createPopulationObservation(Measure measure, String populationId, Coding coding,
+            Integer value) {
+        
+        Observation obs = createObservation(measure,populationId);
+        
+        CodeableConcept obsCodeableConcept = new CodeableConcept();
+        obsCodeableConcept.setCoding(Collections.singletonList(coding));
+        
+        obs.setCode(obsCodeableConcept);
+        obs.setValue(new IntegerType(value));
+        
+        
+        return obs;
+
+    }
+    
+    protected Observation createObservation(Measure measure, String populationId) {
+        MeasureInfo measureInfo = new MeasureInfo()
+                .withMeasure(MeasureInfo.MEASURE_PREFIX + measure.getIdElement().getIdPart())
+                .withPopulationId(populationId);
+        
+        Observation obs = new Observation();
+        obs.setStatus(Observation.ObservationStatus.FINAL);
+        obs.setId(UUID.randomUUID().toString());
+        obs.addExtension( createMeasureInfoExtension(measureInfo) );
+        
+        return obs;
+    }
+    
+    protected Extension createMeasureInfoExtension(MeasureInfo measureInfo) {
+        
+        Extension extExtMeasure = new Extension().setUrl(MeasureInfo.MEASURE)
+                .setValue(new StringType(measureInfo.getMeasure()));
+        
+        Extension extExtPop = new Extension().setUrl(MeasureInfo.POPULATION_ID)
+                .setValue(new StringType(measureInfo.getPopulationId()));
+        
+        Extension obsExtension = new Extension().setUrl(MeasureInfo.EXT_URL);
+        obsExtension.addExtension(extExtMeasure);
+        obsExtension.addExtension(extExtPop);
+        
+        return obsExtension;
+    }
+
+    @Override
+    protected void addEvaluatedResource(MeasureReport report, DomainResource resource) {
+        Bundle resources = getEvaluatedResourcesTarget(report);
+        resources.addEntry().setResource(resource);
+    }
+
+    @Override
+    protected void addContained(MeasureReport report, DomainResource resource) {
+        report.addContained(resource);
+    }
+
+    @Override
+    protected Coding getExtensionCoding(ST patient, String coreCategory, String sdeCode) {
+        Coding valueCoding = new Coding();
+        
+        patient.getExtension().forEach((ptExt) -> {
+            if (ptExt.getUrl().contains(coreCategory)) {
+                Coding extCoding = (Coding) ptExt.getExtension().get(0).getValue();
+                String extCode = getCodingCode(extCoding);
+                if (extCode.equalsIgnoreCase(sdeCode)) {
+                    valueCoding.setSystem(extCoding.getSystem());
+                    valueCoding.setCode(extCoding.getCode());
+                    valueCoding.setDisplay(extCoding.getDisplay());
+                }
+            }
+        });
+        
+        return valueCoding;
+    }
+
+    @Override
+    protected Extension createCodingExtension(String url, String codeSystem, String code) {
+        Extension ext = new Extension().setUrl(url);
+        Coding coding = new Coding().setSystem(codeSystem).setCode(code);
+        ext.setValue(coding);
+        return ext;
+    }
+
+    @Override
+    protected Reference createReference(String resourceId) {
+        return new Reference(resourceId);
+    }
+
+    @Override
+    protected ListResource createListResource(Collection<ListEntryComponent> entries) {
+        ListResource resource = new ListResource();
+        resource.setId(UUID.randomUUID().toString());
+        resource.getEntry().addAll(entries);
+        return resource;
+    }
+
+    @Override
+    protected ListEntryComponent createListEntry(Reference reference) {
+        return new ListEntryComponent().setItem(reference);
+    }
+
+    @Override
+    protected void addExtension(Reference resource, Extension extension) {
+        resource.addExtension(extension);
+    }
+
+    @Override
+    protected void setEvaluatedResources(MeasureReport report, Collection<Reference> evaluatedResources) {
+        Bundle bundle = getEvaluatedResourcesTarget(report);
+        
+        //TODO - discuss the expected semantics with the wider group. The existing
+        // cqf-ruler implementation noops this function right now. Below is a 
+        // proposal that avoids the noop, but may not meet the actual needs of the 
+        // consumer. Is it ok?
+        ListResource list = (ListResource) bundle.getEntryFirstRep().getResource();
+        if( list == null ) {
+            list = new ListResource();
+            list.setTitle("evaluatedResources");
+            list.setId(list.getTitle());
+            bundle.getEntryFirstRep().setResource(list);
+        }
+        
+        for( Reference ref : evaluatedResources ) {
+            list.addEntry(new ListEntryComponent().setItem(ref));
+        }
+        
+        report.addContained( report.getEvaluatedResourcesTarget() );
+        report.setEvaluatedResources(new Reference("#" + bundle.getId()));
+        report.setEvaluatedResourcesTarget(null);
+    }
+
+    private Bundle getEvaluatedResourcesTarget(MeasureReport report) {
+        Bundle bundle = report.getEvaluatedResourcesTarget();
+        if( bundle == null ) {
+            bundle = new Bundle();
+            report.setEvaluatedResourcesTarget(bundle);
+        }
+        
+        if( bundle.getId() == null ) {
+            bundle = new Bundle();
+            bundle.setId(UUID.randomUUID().toString());
+            bundle.setType(Bundle.BundleType.COLLECTION);
+            report.setEvaluatedResourcesTarget(bundle);
+        }
+        return bundle;
     }
 
 

--- a/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/BaseMeasureEvaluationTest.java
+++ b/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/BaseMeasureEvaluationTest.java
@@ -1,0 +1,93 @@
+package org.opencds.cqf.cql.evaluator.measure;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.ModelManager;
+import org.cqframework.cql.elm.execution.Library;
+import org.cqframework.cql.elm.tracking.TrackBack;
+import org.opencds.cqf.cql.engine.execution.CqlLibraryReader;
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+
+public abstract class BaseMeasureEvaluationTest {
+
+    protected static final String FHIR_NS_URI = "http://hl7.org/fhir";
+    protected static final String OMB_CATEGORY_RACE_BLACK = "2054-5";
+    protected static final String BLACK_OR_AFRICAN_AMERICAN = "Black or African American";
+    protected static final String URL_SYSTEM_RACE = "urn:oid:2.16.840.1.113883.6.238";
+    protected static final String OMB_CATEGORY = "ombCategory";
+    protected static final String EXT_URL_US_CORE_RACE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+
+    protected List<Library> translate(String cql) throws Exception {
+        ModelManager modelManager = new ModelManager();
+        LibraryManager libraryManager = new LibraryManager(modelManager);
+        libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
+        CqlTranslator translator = CqlTranslator.fromStream(new ByteArrayInputStream(cql.getBytes()), modelManager, libraryManager);
+    
+        List<CqlTranslatorException> badStuff = new ArrayList<>();
+        // the translator will duplicate exceptions with assigned severity in the errors, warnings, and messages lists
+        badStuff.addAll(translator.getExceptions().stream().filter( e -> e.getSeverity() == null ).collect(Collectors.toList()));
+        badStuff.addAll(translator.getErrors());
+        if( badStuff.size() > 0 ) {
+            throw new Exception("Translation failed - " + formatMsg(badStuff));
+        }
+        
+        List<org.cqframework.cql.elm.execution.Library> cqlLibraries = new ArrayList<>();
+        cqlLibraries.add(CqlLibraryReader.read(new StringReader(translator.toXml())));
+        for( String text : translator.getLibrariesAsXML().values() ) {
+            cqlLibraries.add(CqlLibraryReader.read(new StringReader(text)));
+        }
+        return cqlLibraries;
+    }
+
+    protected Interval measurementPeriod(String periodStart, String periodEnd) {
+        ZoneOffset offset = ZonedDateTime.now().getOffset();
+        
+        DateTime start = new DateTime(periodStart, offset);
+        DateTime end = new DateTime(periodEnd, offset);
+        
+        return new Interval( start, true, end, true );
+    }
+
+    public String skeleton_cql() {
+        return String.format("library Test version '1.0.0'\n\nusing FHIR version '%1$s'\ninclude FHIRHelpers version '%1$s'\n\ncontext Patient\n", getFhirVersion());
+    }
+    
+    public abstract String getFhirVersion();
+
+    protected String sde_race() {
+        return "define \"SDE Race\":\n" + 
+                "  (flatten (\n" + 
+                "    Patient.extension Extension\n" + 
+                "      where Extension.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'\n" + 
+                "        return Extension.extension\n" + 
+                "  )) E\n" + 
+                "    where E.url = 'ombCategory'\n" + 
+                "      or E.url = 'detailed'\n" + 
+                "    return E.value as Coding\n\n";
+    }
+
+    protected static String formatMsg(List<CqlTranslatorException> translationErrs) {
+        StringBuilder msg = new StringBuilder();
+        msg.append("Translation failed due to errors:");
+        for (CqlTranslatorException error : translationErrs) {
+            TrackBack tb = error.getLocator();
+            String lines = tb == null ? "[n/a]"
+                    : String.format("[%d:%d, %d:%d]", tb.getStartLine(), tb.getStartChar(), tb.getEndLine(),
+                            tb.getEndChar());
+            msg.append(String.format("%s %s%n", lines, error.getMessage()));
+        }
+        return msg.toString();
+    }
+
+}

--- a/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/r4/R4MeasureEvaluationTest.java
+++ b/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/r4/R4MeasureEvaluationTest.java
@@ -1,0 +1,227 @@
+package org.opencds.cqf.cql.evaluator.measure.r4;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
+import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.execution.InMemoryLibraryLoader;
+import org.opencds.cqf.cql.engine.execution.LibraryLoader;
+import org.opencds.cqf.cql.engine.fhir.model.R4FhirModelResolver;
+import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.evaluator.measure.BaseMeasureEvaluationTest;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasurePopulationType;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasureReportType;
+import org.testng.annotations.Test;
+
+import ca.uhn.fhir.parser.IParser;
+
+
+public class R4MeasureEvaluationTest extends BaseMeasureEvaluationTest {
+ 
+    public String getFhirVersion() {
+        return "4.0.1";
+    }
+
+    @Test
+    public void testCohortMeasureEvaluation() throws Exception {
+        Patient patient = john_doe();
+        
+        RetrieveProvider retrieveProvider = mock(RetrieveProvider.class);
+        when(retrieveProvider.retrieve(eq("Patient"), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(Arrays.asList(patient));
+        
+        String cql = skeleton_cql() + sde_race() + "define InitialPopulation: 'Doe' in Patient.name.family\n";
+        
+        Measure measure = cohort_measure();
+        
+        MeasureReport report = runTest(cql, patient, measure, retrieveProvider);
+        checkEvidence(patient, report);
+    }
+    
+    @Test
+    public void testProportionMeasureEvaluation() throws Exception {
+        Patient patient = john_doe();
+        
+        RetrieveProvider retrieveProvider = mock(RetrieveProvider.class);
+        when(retrieveProvider.retrieve(eq("Patient"), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(Arrays.asList(patient));
+        
+        String cql = skeleton_cql() + sde_race() + 
+                "define InitialPopulation: 'Doe' in Patient.name.family\n" +
+                "define Denominator: 'John' in Patient.name.given\n" + 
+                "define Numerator: Patient.birthDate > @1970-01-01\n";
+        
+        Measure measure = proportion_measure();
+        
+        MeasureReport report = runTest(cql, patient, measure, retrieveProvider);
+        checkEvidence(patient, report);
+    }
+    
+    @Test
+    public void testContinousVariableMeasureEvaluation() throws Exception {
+        Patient patient = john_doe();
+        
+        RetrieveProvider retrieveProvider = mock(RetrieveProvider.class);
+        when(retrieveProvider.retrieve(eq("Patient"), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(Arrays.asList(patient));
+        
+        String cql = skeleton_cql() + sde_race() + 
+                "define InitialPopulation: 'Doe' in Patient.name.family\n" + 
+                "define MeasurePopulation: Patient.birthDate > @1970-01-01\n";
+        
+        Measure measure = continuous_variable_measure();
+        
+        MeasureReport report = runTest(cql, patient, measure, retrieveProvider);
+        checkEvidence(patient, report);
+    }
+
+    private MeasureReport runTest(String cql, Patient patient, Measure measure, RetrieveProvider retrieveProvider)
+            throws Exception {
+        Interval measurementPeriod = measurementPeriod("2000-01-01", "2001-01-01");
+        
+        Library primaryLibrary = library(cql);
+        measure.addLibrary(primaryLibrary.getId());
+        
+        List<org.cqframework.cql.elm.execution.Library> cqlLibraries = translate(cql);
+        LibraryLoader ll = new InMemoryLibraryLoader(cqlLibraries);
+        
+        R4FhirModelResolver modelResolver = new R4FhirModelResolver();
+        DataProvider dataProvider = new CompositeDataProvider(modelResolver, retrieveProvider);
+        Context context = new Context(cqlLibraries.get(0));
+        context.registerDataProvider(FHIR_NS_URI, dataProvider);
+        context.registerLibraryLoader(ll);
+        
+        R4MeasureEvaluation<Patient> evaluation = new R4MeasureEvaluation<>(context, measure, measurementPeriod, modelResolver.getPackageName(), r -> r.getId() , patient.getId());
+        MeasureReport report = evaluation.evaluate(MeasureReportType.INDIVIDUAL);
+        assertNotNull(report);
+        
+        // Simulate sending it across the wire
+        IParser parser = modelResolver.getFhirContext().newJsonParser();
+        report = (MeasureReport) parser.parseResource( parser.encodeResourceToString(report) );
+        
+        return report;
+    }
+    
+    private void checkEvidence(Patient patient, MeasureReport report) {
+        Map<String,Resource> contained = report.getContained().stream().collect(Collectors.toMap(r -> r.getClass().getSimpleName(), Function.identity()));
+        
+        assertEquals( contained.size(), 1);
+        
+        Observation obs = (Observation) contained.get("Observation");
+        assertNotNull(obs);
+        assertEquals( obs.getValueCodeableConcept().getCodingFirstRep().getCode(), OMB_CATEGORY_RACE_BLACK );
+    }
+
+    private Measure cohort_measure() {
+        
+        Measure measure = measure("cohort");
+        addPopulation(measure, MeasurePopulationType.INITIALPOPULATION, "InitialPopulation");
+        addSDEComponent(measure);
+        
+        return measure;
+    }
+    
+    private Measure proportion_measure() {
+        
+        Measure measure = measure("proportion");
+        addPopulation(measure, MeasurePopulationType.INITIALPOPULATION, "InitialPopulation");
+        addPopulation(measure, MeasurePopulationType.DENOMINATOR, "Denominator");
+        addPopulation(measure, MeasurePopulationType.NUMERATOR, "Numerator");
+        addSDEComponent(measure);
+        
+        return measure;
+    }
+    
+    private Measure continuous_variable_measure() {
+        
+        Measure measure = measure("continuous-variable");
+        addPopulation(measure, MeasurePopulationType.INITIALPOPULATION, "InitialPopulation");
+        addPopulation(measure, MeasurePopulationType.MEASUREPOPULATION, "MeasurePopulation");
+        addSDEComponent(measure);
+        
+        return measure;
+    }
+
+    private void addPopulation(Measure measure, MeasurePopulationType measurePopulationType, String expression) {
+        measure.getGroupFirstRep().getPopulationFirstRep().getCode().getCodingFirstRep().setCode(measurePopulationType.toCode());
+        measure.getGroupFirstRep().getPopulationFirstRep().getCriteria().setExpression(expression);
+    }
+    
+    private void addSDEComponent(Measure measure) {
+        measure.getSupplementalDataFirstRep().getCode().setText("sde-race");
+        measure.getSupplementalDataFirstRep().getCriteria().setLanguage("text/cql").setExpression("SDE Race");
+    }
+
+    private Measure measure(String scoring) {
+        Measure measure = new Measure();
+        measure.setName("Test");
+        measure.setVersion("1.0.0");
+        measure.setUrl("http://test.com/fhir/Measure/Test");
+        measure.getScoring().getCodingFirstRep().setCode(scoring);
+        return measure;
+    }
+
+    private Library library(String cql) {
+        Library library = new Library();
+        library.setId("library-Test");
+        library.setName("Test");
+        library.setVersion("1.0.0");
+        library.setUrl("http://test.com/fhir/Library/Test");
+        library.getType().getCodingFirstRep().setCode("logic-library");
+        library.getContentFirstRep().setContentType("text/cql").setData(cql.getBytes());
+        return library;
+    }
+    
+    private Patient john_doe() {
+        Patient patient = new Patient();
+        patient.setId("test-patient");
+        patient.setName(Arrays.asList(new HumanName().setFamily("Doe").setGiven(Arrays.asList(new StringType("John")))));
+        patient.setBirthDate(new Date());
+        
+        /**
+         * Retrieve the coding from an extension that that looks like the following...
+         * 
+         * {
+         *   "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+         *   "extension": [ {
+         *     "url": "ombCategory",
+         *     "valueCoding": {
+         *       "system": "urn:oid:2.16.840.1.113883.6.238",
+         *       "code": "2054-5",
+         *       "display": "Black or African American"
+         *     }
+         *   } ]
+         * }
+         */
+        
+        Extension usCoreRace = new Extension();
+        usCoreRace.setUrl(EXT_URL_US_CORE_RACE)
+            .addExtension().setUrl(OMB_CATEGORY).setValue(
+                    new Coding().setSystem(URL_SYSTEM_RACE).setCode(OMB_CATEGORY_RACE_BLACK).setDisplay(BLACK_OR_AFRICAN_AMERICAN));
+        patient.getExtension().add(usCoreRace);
+        
+        return patient;
+    }
+}

--- a/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/stu3/Stu3MeasureEvaluationTest.java
+++ b/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/stu3/Stu3MeasureEvaluationTest.java
@@ -1,0 +1,213 @@
+package org.opencds.cqf.cql.evaluator.measure.stu3;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.HumanName;
+import org.hl7.fhir.dstu3.model.Library;
+import org.hl7.fhir.dstu3.model.Measure;
+import org.hl7.fhir.dstu3.model.MeasureReport;
+import org.hl7.fhir.dstu3.model.Observation;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
+import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.execution.InMemoryLibraryLoader;
+import org.opencds.cqf.cql.engine.execution.LibraryLoader;
+import org.opencds.cqf.cql.engine.fhir.model.Dstu3FhirModelResolver;
+import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.evaluator.measure.BaseMeasureEvaluationTest;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasurePopulationType;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasureReportType;
+import org.testng.annotations.Test;
+
+import ca.uhn.fhir.parser.IParser;
+
+public class Stu3MeasureEvaluationTest extends BaseMeasureEvaluationTest {
+
+    public String getFhirVersion() {
+        return "3.0.0";
+    }
+    
+    @Test
+    public void testCohortMeasureEvaluation() throws Exception {
+        Patient patient = john_doe();
+        
+        RetrieveProvider retrieveProvider = mock(RetrieveProvider.class);
+        when(retrieveProvider.retrieve(eq("Patient"), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(Arrays.asList(patient));
+        
+        String cql = skeleton_cql() + sde_race() + 
+                "define InitialPopulation: 'Doe' in Patient.name.family";
+        
+        Measure measure = cohort_measure();
+        
+        MeasureReport report = runTest(cql, patient, measure, retrieveProvider);
+        
+        checkEvidence(report);
+    }
+    
+    @Test
+    public void testProportionMeasureEvaluation() throws Exception {
+        Patient patient = john_doe();
+        
+        RetrieveProvider retrieveProvider = mock(RetrieveProvider.class);
+        when(retrieveProvider.retrieve(eq("Patient"), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(Arrays.asList(patient));
+        
+        String cql = skeleton_cql() + sde_race() + 
+                "define InitialPopulation: 'Doe' in Patient.name.family\n" +
+                "define Denominator: 'John' in Patient.name.given\n" + 
+                "define Numerator: Patient.birthDate > @1970-01-01\n";
+        
+        Measure measure = proportion_measure();
+        
+        MeasureReport report = runTest(cql, patient, measure, retrieveProvider);
+        checkEvidence(report);
+    }
+    
+    @Test
+    public void testContinousVariableMeasureEvaluation() throws Exception {
+        Patient patient = john_doe();
+        
+        RetrieveProvider retrieveProvider = mock(RetrieveProvider.class);
+        when(retrieveProvider.retrieve(eq("Patient"), anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(Arrays.asList(patient));
+        
+        String cql = skeleton_cql() + sde_race() + 
+                "define InitialPopulation: 'Doe' in Patient.name.family\n" + 
+                "define MeasurePopulation: Patient.birthDate > @1970-01-01\n";
+        
+        Measure measure = continuous_variable_measure();
+        
+        MeasureReport report = runTest(cql, patient, measure, retrieveProvider);
+        checkEvidence(report);
+    }
+
+    private MeasureReport runTest(String cql, Patient patient, Measure measure, RetrieveProvider retrieveProvider)
+            throws Exception {
+        Interval measurementPeriod = measurementPeriod("2000-01-01", "2001-01-01");
+        
+        Library primaryLibrary = library(cql);
+        measure.addLibrary(new Reference(primaryLibrary.getId()));
+        
+        List<org.cqframework.cql.elm.execution.Library> cqlLibraries = translate(cql);
+        LibraryLoader ll = new InMemoryLibraryLoader(cqlLibraries);
+        
+        Dstu3FhirModelResolver modelResolver = new Dstu3FhirModelResolver();
+        DataProvider dataProvider = new CompositeDataProvider(modelResolver, retrieveProvider);
+        Context context = new Context(cqlLibraries.get(0));
+        context.registerDataProvider(FHIR_NS_URI, dataProvider);
+        context.registerLibraryLoader(ll);
+        
+        Stu3MeasureEvaluation<Patient> evaluation = new Stu3MeasureEvaluation<>(context, measure, measurementPeriod, modelResolver.getPackageName(), r -> r.getId() , patient.getId());
+        MeasureReport report = evaluation.evaluate(MeasureReportType.INDIVIDUAL);
+        assertNotNull(report);
+        
+        // Simulate sending it across the wire
+        IParser parser = modelResolver.getFhirContext().newJsonParser();
+        report = (MeasureReport) parser.parseResource( parser.encodeResourceToString(report) );
+        return report;
+    }
+    
+    private void checkEvidence(MeasureReport report) {
+        assertNotNull( report.getEvaluatedResources() );
+        assertNotNull( report.getEvaluatedResources().getReference() );
+        String bundleRef = report.getEvaluatedResources().getReference();
+        
+        // The Observation for the SDE and the list of references
+        assertEquals( report.getContained().size(), 2 );
+        Map<String,Resource> contained = report.getContained().stream().collect(Collectors.toMap(r -> r.getClass().getSimpleName(), Function.identity()));
+        
+        Bundle bundle = (Bundle) contained.get("Bundle");
+        assertEquals( bundle.getIdElement().getIdPart(), bundleRef );
+        
+        Observation obs = (Observation) contained.get("Observation");
+        assertEquals( obs.getValueCodeableConcept().getCodingFirstRep().getCode(), OMB_CATEGORY_RACE_BLACK );
+    }
+
+    private Measure cohort_measure() {
+        
+        Measure measure = measure("cohort");
+        addPopulation(measure, MeasurePopulationType.INITIALPOPULATION, "InitialPopulation");
+        measure.getSupplementalDataFirstRep().setCriteria("SDE Race");
+        
+        return measure;
+    }
+    
+    private Measure proportion_measure() {
+        
+        Measure measure = measure("proportion");
+        addPopulation(measure, MeasurePopulationType.INITIALPOPULATION, "InitialPopulation");
+        addPopulation(measure, MeasurePopulationType.DENOMINATOR, "Denominator");
+        addPopulation(measure, MeasurePopulationType.NUMERATOR, "Numerator");
+        measure.getSupplementalDataFirstRep().setCriteria("SDE Race");
+        
+        return measure;
+    }
+    
+    private Measure continuous_variable_measure() {
+        
+        Measure measure = measure("continuous-variable");
+        addPopulation(measure, MeasurePopulationType.INITIALPOPULATION, "InitialPopulation");
+        addPopulation(measure, MeasurePopulationType.MEASUREPOPULATION, "MeasurePopulation");
+        measure.getSupplementalDataFirstRep().setCriteria("SDE Race");
+        
+        return measure;
+    }
+
+    private void addPopulation(Measure measure, MeasurePopulationType populationType, String expression) {
+        measure.getGroupFirstRep().getPopulationFirstRep().getCode().getCodingFirstRep().setCode(populationType.toCode());
+        measure.getGroupFirstRep().getPopulationFirstRep().setCriteria(expression);
+    }
+
+    private Measure measure(String scoring) {
+        Measure measure = new Measure();
+        measure.setName("Test");
+        measure.setVersion("1.0.0");
+        measure.setUrl("http://test.com/fhir/Measure/Test");
+        measure.getScoring().getCodingFirstRep().setCode(scoring);
+        return measure;
+    }
+
+    private Library library(String cql) {
+        Library library = new Library();
+        library.setId("library-Test");
+        library.setName("Test");
+        library.setVersion("1.0.0");
+        library.setUrl("http://test.com/fhir/Library/Test");
+        library.getType().getCodingFirstRep().setCode("logic-library");
+        library.getContentFirstRep().setContentType("text/cql").setData(cql.getBytes());
+        return library;
+    }
+    
+    private Patient john_doe() {
+        Patient patient = new Patient();
+        patient.setId("john-doe");
+        patient.setName(Arrays.asList(new HumanName().setFamily("Doe").setGiven(Arrays.asList(new StringType("John")))));
+        patient.setBirthDate(new Date());
+        
+        Extension usCoreRace = new Extension();
+        usCoreRace.setUrl(EXT_URL_US_CORE_RACE)
+            .addExtension().setUrl(OMB_CATEGORY).setValue(
+                    new Coding().setSystem(URL_SYSTEM_RACE).setCode(OMB_CATEGORY_RACE_BLACK).setDisplay(BLACK_OR_AFRICAN_AMERICAN));
+        patient.getExtension().add(usCoreRace);
+        return patient;
+    }
+}

--- a/evaluator.measure/src/main/java/org/opencds/cqf/cql/evaluator/measure/common/MeasureEvaluation.java
+++ b/evaluator.measure/src/main/java/org/opencds/cqf/cql/evaluator/measure/common/MeasureEvaluation.java
@@ -1,20 +1,33 @@
 package org.opencds.cqf.cql.evaluator.measure.common;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.opencds.cqf.cql.engine.data.DataProvider;
 import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("unchecked")
-public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureGroupComponentT extends BaseT, MeasureGroupPopulationComponentT extends BaseT, MeasureReportT extends BaseT, MeasureReportGroupComponentT extends BaseT, MeasureReportGroupPopulationComponentT extends BaseT, ResourceT, SubjectT extends ResourceT> {
+public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT, MeasureGroupComponentT extends BaseT, MeasureGroupPopulationComponentT extends BaseT,
+    MeasureSupplementalDataComponentT extends BaseT, MeasureReportT extends BaseT, MeasureReportGroupComponentT extends BaseT,
+    MeasureReportGroupPopulationComponentT extends BaseT, CodingT extends BaseT, ExtensionT extends BaseT,
+    ReferenceT extends BaseT, ListResourceT extends ResourceT, ListEntryT extends BaseT, ResourceT, SubjectT extends ResourceT> {
+
+    public static final String URL_CODESYSTEM_MEASURE_POPULATION = "http://teminology.hl7.org/CodeSystem/measure-population";
+
+    public static final String EXT_DAVINCI_POPULATION_REFERENCE = "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-populationReference";
 
     private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluation.class);
 
@@ -52,6 +65,55 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
     protected abstract String getGroupId(MeasureGroupComponentT group);
 
     protected abstract void addReportGroup(MeasureReportT report, MeasureReportGroupComponentT group);
+    
+    protected abstract List<MeasureSupplementalDataComponentT> getSupplementalData(MeasureT measure);
+    
+    protected abstract String getSDEExpression(MeasureSupplementalDataComponentT sdeItem);
+    
+    protected abstract CodingT getSDECoding(MeasureSupplementalDataComponentT sdeItem);
+        
+    protected abstract boolean isCoding(Object obj);
+    
+    protected abstract CodingT createCoding(String text);
+    
+    protected abstract String getCodingCode(CodingT coding);
+    
+    protected abstract ResourceT createPatientObservation(MeasureT measure, String populationId, CodingT coding);
+    
+    protected abstract ResourceT createPopulationObservation(MeasureT measure, String populationId, CodingT coding, Integer value);
+    
+    protected abstract void addEvaluatedResource(MeasureReportT report, ResourceT resource);
+    
+    protected abstract void addContained(MeasureReportT report, ResourceT resource);
+    
+    /**
+     * Retrieve the coding from an extension that that looks like the following...
+     * 
+     * {
+     *   "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+     *   "extension": [ {
+     *     "url": "ombCategory",
+     *     "valueCoding": {
+     *       "system": "urn:oid:2.16.840.1.113883.6.238",
+     *       "code": "2054-5",
+     *       "display": "Black or African American"
+     *     }
+     *   } ]
+     * }
+     */
+    protected abstract CodingT getExtensionCoding(SubjectT patient, String category, String code);
+    
+    protected abstract ExtensionT createCodingExtension(String url, String codeSystem, String code);
+    
+    protected abstract ReferenceT createReference(String resourceId);
+    
+    protected abstract ListResourceT createListResource(Collection<ListEntryT> entries);
+    
+    protected abstract ListEntryT createListEntry(ReferenceT reference);
+    
+    protected abstract void addExtension(ReferenceT resource, ExtensionT extension);
+    
+    protected abstract void setEvaluatedResources(MeasureReportT report, Collection<ReferenceT> evaluatedResources);
 
     public MeasureEvaluation(Context context, MeasureT measure, Interval measurementPeriod, String packageName,
             Function<ResourceT, String> getId) {
@@ -88,29 +150,34 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
             return evaluatePopulationMeasure();
         }
 
+        String id = this.subjectOrPractitionerId;
+        if (id.startsWith("Patient/") ) {
+            id = id.substring("Patient/".length());
+        }
+        
         Iterable<Object> subjectRetrieve = this.getDataProvider().retrieve("Patient", "id",
-                this.subjectOrPractitionerId, "Patient", null, null, null, null, null, null, null, null);
+                id, "Patient", null, null, null, null, null, null, null, null);
         SubjectT patient = null;
         if (subjectRetrieve.iterator().hasNext()) {
             patient = (SubjectT) subjectRetrieve.iterator().next();
         }
 
         return evaluate(patient == null ? Collections.emptyList() : Collections.singletonList(patient),
-                MeasureReportType.INDIVIDUAL);
+                MeasureReportType.INDIVIDUAL, true);
     }
 
     protected MeasureReportT evaluateSubjectListMeasure() {
         logger.info("Generating subject-list report");
         List<SubjectT> subjects = this.subjectOrPractitionerId == null ? getAllSubjects()
                 : getPractitionerSubjects(this.subjectOrPractitionerId);
-        return evaluate(subjects, MeasureReportType.SUBJECTLIST);
+        return evaluate(subjects, MeasureReportType.SUBJECTLIST, false);
     }
 
     protected MeasureReportT evaluatePatientListMeasure() {
         logger.info("Generating patient-list report");
         List<SubjectT> subjects = this.subjectOrPractitionerId == null ? getAllSubjects()
                 : getPractitionerSubjects(this.subjectOrPractitionerId);
-        return evaluate(subjects, MeasureReportType.PATIENTLIST);
+        return evaluate(subjects, MeasureReportType.PATIENTLIST, false);
     }
 
     private List<SubjectT> getPractitionerSubjects(String practitionerRef) {
@@ -136,7 +203,7 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
     public MeasureReportT evaluatePopulationMeasure() {
         logger.info("Generating summary report");
 
-        return evaluate(getAllSubjects(), MeasureReportType.SUMMARY);
+        return evaluate(getAllSubjects(), MeasureReportType.SUMMARY, false);
     }
 
     private Iterable<ResourceT> evaluateCriteria(SubjectT subject, MeasureGroupPopulationComponentT pop) {
@@ -203,15 +270,18 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
         }
     }
 
-    private MeasureReportT evaluate(List<SubjectT> patients, MeasureReportType type) {
+    private MeasureReportT evaluate(List<SubjectT> patients, MeasureReportType type, boolean isSingle) {
         MeasureReportT report = this.createMeasureReport("complete", type, this.measurementPeriod, patients);
         HashMap<String, ResourceT> resources = new HashMap<>();
-        HashMap<String, HashSet<String>> codeToResourceMap = new HashMap<>();
+        HashMap<String, Set<String>> codeToResourceMap = new HashMap<>();
 
         MeasureScoring measureScoring = this.getMeasureScoring();
         if (measureScoring == null) {
             throw new RuntimeException("MeasureType scoring is required in order to calculate.");
         }
+        
+        List<MeasureSupplementalDataComponentT> sde = new ArrayList<>();
+        HashMap<String, HashMap<String, Integer>> sdeAccumulators = null;
 
         for (MeasureGroupComponentT group : this.getGroup()) {
             MeasureReportGroupComponentT reportGroup = this.createReportGroup(this.getGroupId(group));
@@ -250,6 +320,8 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
             HashMap<String, SubjectT> measurePopulationPatients = null;
             HashMap<String, SubjectT> measurePopulationExclusionPatients = null;
 
+            sdeAccumulators = new HashMap<>();
+            sde = getSupplementalData(measure);
             for (MeasureGroupPopulationComponentT pop : this.getPopulation(group)) {
                 MeasurePopulationType populationType = this.getPopulationType(pop);
                 if (populationType != null) {
@@ -364,6 +436,8 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
                                 }
                             }
                         }
+                        
+                        populateSDEAccumulators(measure, context, patient, sdeAccumulators, sde);
                     }
 
                     // Calculate actual MeasureType score, Count(numerator) / Count(denominator)
@@ -396,6 +470,8 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
                                 }
                             }
                         }
+                        
+                        populateSDEAccumulators(measure, context, patient, sdeAccumulators,sde);
                     }
 
                     break;
@@ -409,6 +485,7 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
                         evaluatePopulationCriteria(patient, initialPopulationCriteria,
                                 initialPopulation, initialPopulationPatients, null, null, null);
                         populateResourceMap(MeasurePopulationType.INITIALPOPULATION, resources, codeToResourceMap);
+                        populateSDEAccumulators(measure, context, patient, sdeAccumulators,sde);
                     }
 
                     break;
@@ -442,57 +519,176 @@ public abstract class MeasureEvaluation<BaseT, MeasureT extends BaseT,  MeasureG
                     measurePopulationExclusionPatients != null ? measurePopulationExclusionPatients.values() : null);
             // TODO: MeasureType Observations...
         }
+        
+        List<ReferenceT> evaluatedResourceIds = new ArrayList<>();
+        Map<String, ReferenceT> referenceMap = new HashMap<String, ReferenceT>();
+        for (String code: codeToResourceMap.keySet()) {
+            Set<String> resourceIds = codeToResourceMap.get(code);
+            if( resourceIds.size() > 0 ) {
+                
+                List<ListEntryT> entries = new ArrayList<>(resourceIds.size());
+                for (String resourceId : codeToResourceMap.get(code)) {
+                    if (referenceMap.containsKey(resourceId)) {
+                        ExtensionT ext = createCodingExtension( EXT_DAVINCI_POPULATION_REFERENCE, URL_CODESYSTEM_MEASURE_POPULATION, code);
+                        
+                        ReferenceT ref = referenceMap.get(resourceId);
+                        addExtension( ref, ext );
+                        evaluatedResourceIds.add(ref);
+                    } else {
+                        ExtensionT ext = createCodingExtension( EXT_DAVINCI_POPULATION_REFERENCE, URL_CODESYSTEM_MEASURE_POPULATION, code);
+                        
+                        ReferenceT reference = createReference(resourceId);
+                        addExtension(reference, ext);
+                        
+                        ListEntryT comp = createListEntry(reference);
+                        entries.add(comp);
+                        // Do not want to add extension to ListEntryReference
+    
+                        evaluatedResourceIds.add(reference);
+                        referenceMap.put(resourceId, reference);
+                    }
+                }
+    
+                ListResourceT list = createListResource(entries);
+                resources.put(this.getId.apply(list), list);
+            }
+        }
+        setEvaluatedResources(report, evaluatedResourceIds);
 
-        // for (String key : codeToResourceMap.keySet()) {
-        // list = new ListResource();
-        // for (String element : codeToResourceMap.get(key)) {
-        // ListResource.ListEntryComponent comp = new ListEntryComponent();
-        // comp.setItem(new Reference('#' + element));
-        // list.addEntry(comp);
-        // }
-
-        // if (!list.isEmpty()) {
-        // list.setId(UUID.randomUUID().toString());
-        // list.setTitle(key);
-        // resources.put(list.getId(), list);
-        // }
-        // }
-
-        // if (!resources.isEmpty()) {
-        // FhirMeasureBundler bundler = new FhirMeasureBundler();
-        // Bundle evaluatedResources = bundler.bundle(resources.values());
-        // evaluatedResources.setId(UUID.randomUUID().toString());
-        // report.setEvaluatedResource(Collections.singletonList(new Reference('#' +
-        // evaluatedResources.getId())));
-        // report.addContained(evaluatedResources);
-        // }
+        if (sdeAccumulators.size() > 0) {
+            report = processAccumulators(measure, report, sdeAccumulators, sde, isSingle, patients);
+        }
 
         return report;
     }
+    
+    private void populateSDEAccumulators(MeasureT measure, Context context, SubjectT patient,
+            HashMap<String, HashMap<String, Integer>> sdeAccumulators,
+            List<MeasureSupplementalDataComponentT> sde) {
+        context.setContextValue("Patient", this.getId.apply(patient));
+        List<Object> sdeList = sde.stream()
+                .map(sdeItem -> context.resolveExpressionRef(getSDEExpression(sdeItem)).evaluate(context))
+                .collect(Collectors.toList());
+        if (!sdeList.isEmpty()) {
+            for (int i = 0; i < sdeList.size(); i++) {
+                Object sdeListItem = sdeList.get(i);
+                if (null != sdeListItem) {
+                    String sdeAccumulatorKey = getCodingCode( getSDECoding(sde.get(i)) );
+                    if (null == sdeAccumulatorKey || sdeAccumulatorKey.length() < 1) {
+                        String expression = getSDEExpression(sde.get(i));
+                        if( expression != null ) {
+                            sdeAccumulatorKey = expression.toLowerCase(Locale.ROOT).replace(" ", "-");
+                        }
+                    }
 
-    private void populateResourceMap(MeasurePopulationType type, HashMap<String, ResourceT> resources,
-            HashMap<String, HashSet<String>> codeToResourceMap) {
+                    HashMap<String, Integer> sdeItemMap = sdeAccumulators.get(sdeAccumulatorKey);
+                    String code = "";
+
+                    if( sdeListItem instanceof Code ) {
+                        code = ((Code) sdeListItem).getCode();
+                    } else if( sdeListItem instanceof List ) {
+                        List<?> list = (List<?>) sdeListItem;
+                        if( ! list.isEmpty() ) {
+                            Object first = list.get(0);
+                            if( first instanceof Code ) {
+                                code = ((Code) first).getCode();
+                            } else if( isCoding(first) ) {
+                                code = getCodingCode( (CodingT) first );
+                            }
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                    
+                    if (null == code) {
+                        continue;
+                    }
+                    if (null != sdeItemMap && null != sdeItemMap.get(code)) {
+                        Integer sdeItemValue = sdeItemMap.get(code);
+                        sdeItemValue++;
+                        sdeItemMap.put(code, sdeItemValue);
+                        sdeAccumulators.get(sdeAccumulatorKey).put(code, sdeItemValue);
+                    } else {
+                        if (null == sdeAccumulators.get(sdeAccumulatorKey)) {
+                            HashMap<String, Integer> newSDEItem = new HashMap<>();
+                            newSDEItem.put(code, 1);
+                            sdeAccumulators.put(sdeAccumulatorKey, newSDEItem);
+                        } else {
+                            sdeAccumulators.get(sdeAccumulatorKey).put(code, 1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private MeasureReportT processAccumulators(MeasureT measure, MeasureReportT report,
+            HashMap<String, HashMap<String, Integer>> sdeAccumulators,
+            List<MeasureSupplementalDataComponentT> sde, boolean isSingle, List<SubjectT> patients) {
+        sdeAccumulators.forEach((sdeKey, sdeAccumulator) -> {
+            sdeAccumulator.forEach((sdeAccumulatorKey, sdeAccumulatorValue) -> {
+
+                CodingT valueCoding = createCoding(sdeAccumulatorKey);
+                if (! sdeKey.equalsIgnoreCase("sde-sex")) {
+                    
+                    /** 
+                     * Match up the category part of our SDE key (e.g. sde-race has a category of race) with a 
+                     * patient extension of the same category (e.g. http://hl7.org/fhir/us/core/StructureDefinition/us-core-race)
+                     * and the same code as sdeAccumulatorKey (aka the value extracted from the CQL expression
+                     * named in the Measure SDE metadata) and then record the coding details.
+                     * 
+                     * We know that at least one patient matches the sdeAccumulatorKey or else it wouldn't show up
+                     * in the map.
+                     */
+                    
+                    String coreCategory = sdeKey.substring(sdeKey.lastIndexOf('-') >= 0 ? sdeKey.lastIndexOf('-') : 0);
+                    for( SubjectT pt : patients ) {
+                        valueCoding = getExtensionCoding(pt, coreCategory, sdeAccumulatorKey);
+                        
+                        //TODO - Is there any reason to continue looking at additional patients? The original 
+                        // cqf-ruler implementation would use the last matching patient's data vs. the first.
+                        if( valueCoding != null ) {
+                            break;
+                        }
+                    }
+                }
+                
+                ResourceT obs;
+                if (isSingle) {
+                    obs = createPatientObservation(measure, sdeKey, valueCoding);
+                } else {
+                    obs = createPopulationObservation(measure, sdeKey, valueCoding, sdeAccumulatorValue);
+                }
+                
+                addEvaluatedResource( report, obs );
+                addContained(report, obs);
+                //newRefList.add(new Reference("#" + this.getId.apply(obs)));
+                //report.addContained(obs);
+            });
+        });
+        //newRefList.addAll(report.getEvaluatedResource());
+        //report.setEvaluatedResource(newRefList);
+        return report;
+    }
+
+    private void populateResourceMap(MeasurePopulationType type, Map<String, ResourceT> resources,
+            Map<String, Set<String>> codeToResourceMap) {
         if (this.context.getEvaluatedResources().isEmpty()) {
             return;
         }
 
-        if (!codeToResourceMap.containsKey(type.toCode())) {
-            codeToResourceMap.put(type.toCode(), new HashSet<>());
-        }
-
-        HashSet<String> codeHashSet = codeToResourceMap.get((type.toCode()));
+        Set<String> codeSet = codeToResourceMap.computeIfAbsent(type.toCode(), key -> new HashSet<>());
 
         for (Object o : this.context.getEvaluatedResources()) {
             try {
                 ResourceT r = (ResourceT) o;
                 String id = this.getId.apply(r);
-                if (!codeHashSet.contains(id)) {
-                    codeHashSet.add(id);
-                }
+                
+                codeSet.add(id);
+                resources.computeIfAbsent(id, key -> r);
 
-                if (!resources.containsKey(id)) {
-                    resources.put(id, r);
-                }
             } catch (Exception e) {
             }
         }

--- a/evaluator.measure/src/main/java/org/opencds/cqf/cql/evaluator/measure/common/MeasureInfo.java
+++ b/evaluator.measure/src/main/java/org/opencds/cqf/cql/evaluator/measure/common/MeasureInfo.java
@@ -1,0 +1,46 @@
+package org.opencds.cqf.cql.evaluator.measure.common;
+
+public class MeasureInfo {
+    public static final String EXT_URL = "http://hl7.org/fhir/StructureDefinition/cqf-measureInfo";
+    public static final String MEASURE_PREFIX = "http://hl7.org/fhir/us/cqfmeasures/";
+    
+    
+    public static final String MEASURE = "measure";
+    public static final String GROUP_ID = "groupId";
+    public static final String POPULATION_ID = "populationId";
+    
+    private String measure;
+    private String groupId;
+    private String populationId;
+    
+    public MeasureInfo() {
+        
+    }
+
+    public String getMeasure() {
+        return measure;
+    }
+
+    public MeasureInfo withMeasure(String canonical) {
+        this.measure = canonical;
+        return this;
+    }
+    
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public MeasureInfo withGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public String getPopulationId() {
+        return populationId;
+    }
+
+    public MeasureInfo withPopulationId(String populationId) {
+        this.populationId = populationId;
+        return this;
+    }
+}


### PR DESCRIPTION
I pulled over SDE logic from cqf-ruler and made it reusable across different FHIR versions / models. I added some basic unit tests to verify the things that I changed, but those could be fleshed out quite a bit more.