### PR TITLE
QuickFix for Empty translatorOptions

### DIFF
--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/util/TranslatorOptionsUtil.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/util/TranslatorOptionsUtil.java
@@ -112,6 +112,11 @@ public class TranslatorOptionsUtil {
         }
 
         EnumSet<CqlTranslator.Options> optionSet = EnumSet.noneOf(CqlTranslator.Options.class);
+
+        if (translatorOptions.trim().isEmpty()) {
+            return optionSet;
+        }
+
         String[] options = translatorOptions.trim().split(",");
 
         for (String option : options) {


### PR DESCRIPTION
Solving for an `elm/json` library with: 

```
    "annotation" : [ {
      "translatorOptions" : ""
    } ]
```

Which gives 

```
java.lang.IllegalArgumentException: No enum constant org.cqframework.cql.cql2elm.CqlTranslator.Options.
at java.lang.Enum.valueOf(Enum.java:257)
at org.cqframework.cql.cql2elm.CqlTranslator$Options.valueOf(CqlTranslator.java:38)
at org.opencds.cqf.cql.evaluator.engine.util.TranslatorOptionsUtil.parseTranslatorOptions(TranslatorOptionsUtil.java:117)
at org.opencds.cqf.cql.evaluator.engine.util.TranslatorOptionsUtil.getTranslatorOptions(TranslatorOptionsUtil.java:41)
at org.opencds.cqf.cql.evaluator.engine.execution.TranslatingLibraryLoader.translatorOptionsMatch(TranslatingLibraryLoader.java:101)
at org.opencds.cqf.cql.evaluator.engine.execution.TranslatingLibraryLoader.load(TranslatingLibraryLoader.java:74)
at org.opencds.cqf.cql.evaluator.engine.execution.CacheAwareLibraryLoaderDecorator.load(CacheAwareLibraryLoaderDecorator.java:49)
at org.opencds.cqf.cql.engine.execution.CqlEngine.loadAndValidate(CqlEngine.java:254)
at org.opencds.cqf.cql.engine.execution.CqlEngine.evaluate(CqlEngine.java:154)
at org.opencds.cqf.cql.evaluator.CqlEvaluator.evaluate(CqlEvaluator.java:89)
at org.opencds.cqf.cql.evaluator.library.LibraryEvaluator.evaluate(LibraryEvaluator.java:47)
at org.opencds.cqf.cql.evaluator.library.LibraryProcessor.evaluate(LibraryProcessor.java:159)
at org.opencds.cqf.cql.evaluator.library.LibraryProcessor.evaluate(LibraryProcessor.java:93)
```

on [CqlTranslator.Options.valueOf(option)](https://github.com/DBCG/cql-evaluator/blob/9edcab465de2e710e07dc45f01704c2fee70e2a0/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/util/TranslatorOptionsUtil.java#L118) with `option=""`