### PR TITLE
Add extension to suplemental Data evaluated resources

### DIFF
--- a/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/r4/MeasureProcessorSdeAddCriteriaExtensionTest.java
+++ b/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/r4/MeasureProcessorSdeAddCriteriaExtensionTest.java
@@ -1,0 +1,34 @@
+package org.opencds.cqf.cql.evaluator.measure.r4;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.opencds.cqf.cql.evaluator.measure.common.MeasureConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+@Test(singleThreaded = true)
+public class MeasureProcessorSdeAddCriteriaExtensionTest extends BaseMeasureProcessorTest {
+    public MeasureProcessorSdeAddCriteriaExtensionTest() {
+        super("ClientNonPatientBasedMeasureBundle.json");
+    }
+
+    @Test
+    public void exm124_subject_list() {
+        MeasureReport report = this.measureProcessor.evaluateMeasure("http://nhsnlink.org/fhir/Measure/InitialInpatientPopulation",
+                "2019-01-01", "2020-01-01", "subject",
+                "Patient/97f27374-8a5c-4aa1-a26f-5a1ab03caa47", null, null,
+                endpoint, endpoint, endpoint, null);
+
+        for(Extension extension :report.getExtension()) {
+            if(StringUtils.equalsIgnoreCase(extension.getUrl(), MeasureConstants.SDE_EXT_URL)) {
+                if(!extension.getExtension().isEmpty()) {
+                    assertEquals(extension.getExtension().get(0).getUrl(), MeasureConstants.SDE_CRITERIA_REF_URL);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/evaluator.measure/src/main/java/org/opencds/cqf/cql/evaluator/measure/common/MeasureConstants.java
+++ b/evaluator.measure/src/main/java/org/opencds/cqf/cql/evaluator/measure/common/MeasureConstants.java
@@ -6,6 +6,12 @@ public class MeasureConstants {
 
     public static final String EXT_DAVINCI_POPULATION_REFERENCE = "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-populationReference";
 
+    public static final String SDE_EXT_URL = "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-supplementalData";
+
+    // to do this is a made up url, needs to be defined
+    public static final String SDE_CRITERIA_REF_URL = "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-populationReference";
+
+
     public static final String MEASUREMENT_PERIOD_PARAMETER_NAME = "Measurement Period";
 
     public static final String FHIR_MODEL_URI = "http://hl7.org/fhir";


### PR DESCRIPTION
The output MeasureReport extension looks like this:
![image](https://user-images.githubusercontent.com/31050924/173105294-2b186a1e-d426-40c7-9c21-e7e43b4976b1.png)
