### PR TITLE
Dependency clean up

### DIFF
--- a/evaluator.fhir/pom.xml
+++ b/evaluator.fhir/pom.xml
@@ -23,6 +23,25 @@
             <artifactId>evaluator</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+        <!-- Engine Dependencies for FHIR -->
+        <dependency>
+            <groupId>org.opencds.cqf.cql</groupId>
+            <artifactId>engine.fhir</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
+            <artifactId>fhir-r4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
+            <artifactId>elm-fhir</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
+            <artifactId>quick</artifactId>
+        </dependency>
+
+        <!-- Additional HAPI FHIR Dependencies the Engine does not import -->
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-dstu3</artifactId>

--- a/evaluator.fhir/pom.xml
+++ b/evaluator.fhir/pom.xml
@@ -25,10 +25,6 @@
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-dstu3</artifactId>
         </dependency>
         <dependency>

--- a/evaluator.fhir/pom.xml
+++ b/evaluator.fhir/pom.xml
@@ -19,10 +19,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator</artifactId>
             <version>2.0.0-SNAPSHOT</version>

--- a/evaluator.measure-hapi/pom.xml
+++ b/evaluator.measure-hapi/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
+            <artifactId>evaluator</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.fhir</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
@@ -32,6 +37,7 @@
             <artifactId>evaluator.builder</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.jaxb-deps</artifactId>

--- a/evaluator/pom.xml
+++ b/evaluator/pom.xml
@@ -23,56 +23,50 @@
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>engine</artifactId>
-            <version>${cql-engine.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opencds.cqf.cql</groupId>
-            <artifactId>engine.fhir</artifactId>
-            <version>${cql-engine.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-to-elm</artifactId>
-            <version>${cql-translator.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>elm</artifactId>
-            <version>${cql-translator.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>model</artifactId>
-            <version>${cql-translator.version}</version>
+        </dependency>
+        <!-- Required for MapStruct Annotations -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+
+        <!-- FHIR, Quick and QDM are not required to compile -->
+        <dependency>
+            <groupId>org.opencds.cqf.cql</groupId>
+            <artifactId>engine.fhir</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>qdm</artifactId>
-            <version>${cql-translator.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>quick</artifactId>
-            <version>${cql-translator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>info.cqframework</groupId>
-            <artifactId>cqf-fhir</artifactId>
-            <version>${cql-translator.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>fhir-r4</artifactId>
-            <version>${cql-translator.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>elm-fhir</artifactId>
-            <version>${cql-translator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/evaluator/pom.xml
+++ b/evaluator/pom.xml
@@ -78,10 +78,6 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>

--- a/evaluator/pom.xml
+++ b/evaluator/pom.xml
@@ -74,10 +74,6 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,53 @@
                 <version>1.0.3</version>
             </dependency>
 
+            <!-- Engine Dependencies -->
+            <dependency>
+                <groupId>org.opencds.cqf.cql</groupId>
+                <artifactId>engine</artifactId>
+                <version>${cql-engine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>cql-to-elm</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>elm</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>model</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opencds.cqf.cql</groupId>
+                <artifactId>engine.fhir</artifactId>
+                <version>${cql-engine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>qdm</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>quick</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>fhir-r4</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>elm-fhir</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+
             <!-- HAPI depedencies -->
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,11 +154,6 @@
                 <artifactId>hapi-fhir-validation-resources-r5</artifactId>
                 <version>${hapi.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.github.ben-manes.caffeine</groupId>
-                <artifactId>caffeine</artifactId>
-                <version>${caffeine.version}</version>
-            </dependency>
 
             <!-- CLI -->
             <dependency>
@@ -234,6 +229,12 @@
                 <version>${spring.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
+                <scope>test</scope>
+            </dependency>
 
 
             <!-- Logging -->
@@ -286,6 +287,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,7 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Moves jcl-over-slf4j to test scope.
Moves Caffeine to test scope.
Removes hapi-fhir-client (still available from org.opencds.cqf.cql:engine.fhir:2.0.0)
Removes javax.annotations (I am not sure why this was here)
Centralizes FHIR Dependencies on the evaluator.fhir, where they are actually being used. 