### PR TITLE
Engine 2.0 w jackson module upgrade

### DIFF
--- a/evaluator.activitydefinition/pom.xml
+++ b/evaluator.activitydefinition/pom.xml
@@ -41,13 +41,6 @@
 
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
-            <artifactId>evaluator.jaxb-deps</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.jackson-deps</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>pom</type>

--- a/evaluator.builder/src/main/java/org/opencds/cqf/cql/evaluator/builder/CqlEvaluatorBuilder.java
+++ b/evaluator.builder/src/main/java/org/opencds/cqf/cql/evaluator/builder/CqlEvaluatorBuilder.java
@@ -16,7 +16,7 @@ import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.cqframework.cql.cql2elm.model.Model;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
 import org.cqframework.cql.elm.execution.Library;
-import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
@@ -51,7 +51,7 @@ public class CqlEvaluatorBuilder {
 
     private static Logger logger = LoggerFactory.getLogger(CqlEvaluatorBuilder.class);
 
-    private static Map<VersionedIdentifier, Model> globalModelCache = new HashMap<>();
+    private static Map<ModelIdentifier, Model> globalModelCache = new HashMap<>();
 
     private List<LibrarySourceProvider> librarySourceProviders;
 

--- a/evaluator.expression/pom.xml
+++ b/evaluator.expression/pom.xml
@@ -39,13 +39,6 @@
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
-            <artifactId>evaluator.jaxb-deps</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.jackson-deps</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>pom</type>

--- a/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/AdditionalRequestHeadersInterceptor.java
+++ b/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/AdditionalRequestHeadersInterceptor.java
@@ -1,0 +1,122 @@
+package org.opencds.cqf.cql.evaluator.fhir;
+
+/*-
+ * #%L
+ * HAPI FHIR - Client Framework
+ * %%
+ * Copyright (C) 2014 - 2022 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This file is a copy of AdditionalRequestHeadersInterceptor from the HAPI-FHIR-Client package.
+ * It was brought over to remove the need to import the HAPI-FHIR-Client library due to incompatibility with Android.
+ * Hopefully, HAPI creates a generic version of Interceptors that are independent of the HTTP Client
+ * implementation.
+ *
+ * This interceptor adds arbitrary header values to requests made by the client.
+ *
+ * This is now also possible directly on the Fluent Client API by calling
+ * {@link ca.uhn.fhir.rest.gclient.IClientExecutable#withAdditionalHeader(String, String)}
+ */
+public class AdditionalRequestHeadersInterceptor {
+	private final Map<String, List<String>> myAdditionalHttpHeaders;
+
+	/**
+	 * Constructor
+	 */
+	public AdditionalRequestHeadersInterceptor() {
+		myAdditionalHttpHeaders = new HashMap<>();
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param theHeaders The additional headers to add to every request
+	 */
+	public AdditionalRequestHeadersInterceptor(Map<String, List<String>> theHeaders) {
+		this();
+		if (theHeaders != null) {
+			myAdditionalHttpHeaders.putAll(theHeaders);
+		}
+	}
+
+	/**
+	 * Adds the given header value.
+	 * Note that {@code headerName} and {@code headerValue} cannot be null.
+	 * @param headerName the name of the header
+	 * @param headerValue the value to add for the header
+	 * @throws NullPointerException if either parameter is {@code null}
+	 */
+	public void addHeaderValue(String headerName, String headerValue) {
+		Objects.requireNonNull(headerName, "headerName cannot be null");
+		Objects.requireNonNull(headerValue, "headerValue cannot be null");
+
+		getHeaderValues(headerName).add(headerValue);
+	}
+
+	/**
+	 * Adds the list of header values for the given header.
+	 * Note that {@code headerName} and {@code headerValues} cannot be null.
+	 * @param headerName the name of the header
+	 * @param headerValues the list of values to add for the header
+	 * @throws NullPointerException if either parameter is {@code null}
+	 */
+	public void addAllHeaderValues(String headerName, List<String> headerValues) {
+		Objects.requireNonNull(headerName, "headerName cannot be null");
+		Objects.requireNonNull(headerValues, "headerValues cannot be null");
+
+		getHeaderValues(headerName).addAll(headerValues);
+	}
+
+	/**
+	 * Gets the header values list for a given header.
+	 * If the header doesn't have any values, an empty list will be returned.
+	 * @param headerName the name of the header
+	 * @return the list of values for the header
+	 */
+	private List<String> getHeaderValues(String headerName) {
+		if (myAdditionalHttpHeaders.get(headerName) == null) {
+			myAdditionalHttpHeaders.put(headerName, new ArrayList<>());
+		}
+		return myAdditionalHttpHeaders.get(headerName);
+	}
+
+	/**
+	 * Adds the additional header values to the HTTP request.
+	 * @param theRequest the HTTP request
+	 */
+	@Hook(Pointcut.CLIENT_REQUEST)
+	public void interceptRequest(IHttpRequest theRequest) {
+		for (Map.Entry<String, List<String>> header : myAdditionalHttpHeaders.entrySet()) {
+			for (String headerValue : header.getValue()) {
+				if (headerValue != null) {
+					theRequest.addHeader(header.getKey(), headerValue);
+				}
+			}
+		}
+	}
+
+}

--- a/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/ClientFactory.java
+++ b/evaluator.fhir/src/main/java/org/opencds/cqf/cql/evaluator/fhir/ClientFactory.java
@@ -2,7 +2,6 @@ package org.opencds.cqf.cql.evaluator.fhir;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.client.interceptor.AdditionalRequestHeadersInterceptor;
 
 import java.util.HashMap;
 import java.util.List;

--- a/evaluator.jackson-deps/pom.xml
+++ b/evaluator.jackson-deps/pom.xml
@@ -23,12 +23,14 @@
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>model-jackson</artifactId>
-            <version>${cql-translator.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>elm-jackson</artifactId>
-            <version>${cql-translator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opencds.cqf.cql</groupId>
+            <artifactId>engine.jackson</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/evaluator.jaxb-deps/pom.xml
+++ b/evaluator.jaxb-deps/pom.xml
@@ -35,7 +35,10 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
-            <version>2.7.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/evaluator.jaxb-deps/pom.xml
+++ b/evaluator.jaxb-deps/pom.xml
@@ -23,17 +23,14 @@
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>engine.jaxb</artifactId>
-            <version>${cql-engine.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>model-jaxb</artifactId>
-            <version>${cql-translator.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>elm-jaxb</artifactId>
-            <version>${cql-translator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/evaluator.library/pom.xml
+++ b/evaluator.library/pom.xml
@@ -35,13 +35,6 @@
         </dependency>
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
-            <artifactId>evaluator.jaxb-deps</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.jackson-deps</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>pom</type>

--- a/evaluator.measure-hapi/pom.xml
+++ b/evaluator.measure-hapi/pom.xml
@@ -40,13 +40,6 @@
 
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
-            <artifactId>evaluator.jaxb-deps</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.jackson-deps</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>pom</type>

--- a/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/dstu3/Dstu3MeasureProcessor.java
+++ b/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/dstu3/Dstu3MeasureProcessor.java
@@ -17,6 +17,7 @@ import org.cqframework.cql.cql2elm.model.Model;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
 import org.cqframework.cql.elm.execution.Library;
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Endpoint;
 import org.hl7.fhir.dstu3.model.Measure;
@@ -71,7 +72,7 @@ public class Dstu3MeasureProcessor implements MeasureProcessor<MeasureReport, En
     protected LibrarySourceProviderFactory librarySourceProviderFactory;
     protected FhirDalFactory fhirDalFactory;
 
-    private static Map<org.hl7.elm.r1.VersionedIdentifier, Model> globalModelCache = new ConcurrentHashMap<>();
+    private static Map<ModelIdentifier, Model> globalModelCache = new ConcurrentHashMap<>();
 
     private Map<org.cqframework.cql.elm.execution.VersionedIdentifier, org.cqframework.cql.elm.execution.Library> libraryCache;
 

--- a/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/r4/R4MeasureProcessor.java
+++ b/evaluator.measure-hapi/src/main/java/org/opencds/cqf/cql/evaluator/measure/r4/R4MeasureProcessor.java
@@ -17,6 +17,7 @@ import org.cqframework.cql.cql2elm.model.Model;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
 import org.cqframework.cql.elm.execution.Library;
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CanonicalType;
@@ -77,7 +78,7 @@ public class R4MeasureProcessor implements MeasureProcessor<MeasureReport, Endpo
     protected LibrarySourceProviderFactory librarySourceProviderFactory;
     protected FhirDalFactory fhirDalFactory;
 
-    private static Map<org.hl7.elm.r1.VersionedIdentifier, Model> globalModelCache = new ConcurrentHashMap<>();
+    private static Map<ModelIdentifier, Model> globalModelCache = new ConcurrentHashMap<>();
 
     private Map<org.cqframework.cql.elm.execution.VersionedIdentifier, org.cqframework.cql.elm.execution.Library> libraryCache;
 

--- a/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/BaseMeasureEvaluationTest.java
+++ b/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/BaseMeasureEvaluationTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.LibraryContentType;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
@@ -18,6 +19,7 @@ import org.cqframework.cql.elm.tracking.TrackBack;
 import org.opencds.cqf.cql.engine.execution.CqlLibraryReader;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderFactory;
 
 public abstract class BaseMeasureEvaluationTest {
 
@@ -43,9 +45,10 @@ public abstract class BaseMeasureEvaluationTest {
         }
 
         List<org.cqframework.cql.elm.execution.Library> cqlLibraries = new ArrayList<>();
-        cqlLibraries.add(CqlLibraryReader.read(new StringReader(translator.toXml())));
+        var reader = CqlLibraryReaderFactory.getReader(LibraryContentType.XML.mimeType());
+        cqlLibraries.add(reader.read(new StringReader(translator.toXml())));
         for( String text : translator.getLibrariesAsXML().values() ) {
-            cqlLibraries.add(CqlLibraryReader.read(new StringReader(text)));
+            cqlLibraries.add(reader.read(new StringReader(text)));
         }
         return cqlLibraries;
     }

--- a/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/BaseMeasureEvaluationTest.java
+++ b/evaluator.measure-hapi/src/test/java/org/opencds/cqf/cql/evaluator/measure/BaseMeasureEvaluationTest.java
@@ -16,7 +16,6 @@ import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
 import org.cqframework.cql.elm.execution.Library;
 import org.cqframework.cql.elm.tracking.TrackBack;
-import org.opencds.cqf.cql.engine.execution.CqlLibraryReader;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderFactory;

--- a/evaluator.plandefinition/pom.xml
+++ b/evaluator.plandefinition/pom.xml
@@ -51,13 +51,6 @@
 
         <dependency>
             <groupId>org.opencds.cqf.cql</groupId>
-            <artifactId>evaluator.jaxb-deps</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opencds.cqf.cql</groupId>
             <artifactId>evaluator.jackson-deps</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>pom</type>

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/cql2elm/model/CacheAwareModelManager.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/cql2elm/model/CacheAwareModelManager.java
@@ -6,29 +6,29 @@ import org.cqframework.cql.cql2elm.ModelInfoLoader;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.Model;
 import org.cqframework.cql.cql2elm.model.SystemModel;
-import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
+import org.hl7.cql.model.ModelIdentifier;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * This class extends the CQL translator {@link org.cqframework.cql.cql2elm.ModelManager} class to be aware of a global cache of {@link org.cqframework.cql.cql2elm.model.Model}s
- * The global cache is by @{org.hl7.elm.r1.VersionedIdentifier}, while the local cache is by name. This is because the translator expects the ModelManager to only permit loading
+ * The global cache is by @{org.hl7.elm.r1.ModelIndentifer}, while the local cache is by name. This is because the translator expects the ModelManager to only permit loading
  * of a single version version of a given Model in a single translation context, while the global cache is for all versions of Models
  */
 public class CacheAwareModelManager extends ModelManager {
 
-    private final Map<VersionedIdentifier, Model> globalCache;
+    private final Map<ModelIndentifer, Model> globalCache;
 
     private final Map<String, Model> localCache;
 
     private final ModelInfoLoader modelInfoLoader;
 
     /**
-     * @param globalCache cache for Models by VersionedIdentifier. Expected to be thread-safe.
+     * @param globalCache cache for Models by ModelIndentifer. Expected to be thread-safe.
      */
-    public CacheAwareModelManager(Map<VersionedIdentifier, Model> globalCache) {
+    public CacheAwareModelManager(Map<ModelIndentifer, Model> globalCache) {
         requireNonNull(globalCache, "globalCache can not be null.");
 
         this.globalCache = globalCache;
@@ -36,7 +36,7 @@ public class CacheAwareModelManager extends ModelManager {
         this.modelInfoLoader = new ModelInfoLoader();
     }
 
-	private Model buildModel(VersionedIdentifier identifier) {
+	private Model buildModel(ModelIndentifer identifier) {
         Model model = null;
         try {
 
@@ -62,7 +62,7 @@ public class CacheAwareModelManager extends ModelManager {
      */
 
     @Override
-    public Model resolveModel(VersionedIdentifier modelIdentifier) {
+    public Model resolveModel(ModelIndentifer modelIdentifier) {
         Model model = null;
         if (this.localCache.containsKey(modelIdentifier.getId())) {
             model = this.localCache.get(modelIdentifier.getId());

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/cql2elm/model/CacheAwareModelManager.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/cql2elm/model/CacheAwareModelManager.java
@@ -14,21 +14,21 @@ import java.util.Map;
 
 /**
  * This class extends the CQL translator {@link org.cqframework.cql.cql2elm.ModelManager} class to be aware of a global cache of {@link org.cqframework.cql.cql2elm.model.Model}s
- * The global cache is by @{org.hl7.elm.r1.ModelIndentifer}, while the local cache is by name. This is because the translator expects the ModelManager to only permit loading
+ * The global cache is by @{org.hl7.cql.model.ModelIdentifier}, while the local cache is by name. This is because the translator expects the ModelManager to only permit loading
  * of a single version version of a given Model in a single translation context, while the global cache is for all versions of Models
  */
 public class CacheAwareModelManager extends ModelManager {
 
-    private final Map<ModelIndentifer, Model> globalCache;
+    private final Map<ModelIdentifier, Model> globalCache;
 
     private final Map<String, Model> localCache;
 
     private final ModelInfoLoader modelInfoLoader;
 
     /**
-     * @param globalCache cache for Models by ModelIndentifer. Expected to be thread-safe.
+     * @param globalCache cache for Models by ModelIdentifier. Expected to be thread-safe.
      */
-    public CacheAwareModelManager(Map<ModelIndentifer, Model> globalCache) {
+    public CacheAwareModelManager(Map<ModelIdentifier, Model> globalCache) {
         requireNonNull(globalCache, "globalCache can not be null.");
 
         this.globalCache = globalCache;
@@ -36,7 +36,7 @@ public class CacheAwareModelManager extends ModelManager {
         this.modelInfoLoader = new ModelInfoLoader();
     }
 
-	private Model buildModel(ModelIndentifer identifier) {
+	private Model buildModel(ModelIdentifier identifier) {
         Model model = null;
         try {
 
@@ -62,7 +62,7 @@ public class CacheAwareModelManager extends ModelManager {
      */
 
     @Override
-    public Model resolveModel(ModelIndentifer modelIdentifier) {
+    public Model resolveModel(ModelIdentifier modelIdentifier) {
         Model model = null;
         if (this.localCache.containsKey(modelIdentifier.getId())) {
             model = this.localCache.get(modelIdentifier.getId());

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -80,7 +80,6 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
                     return CqlLibraryReaderFactory.getReader(type.mimeType()).read(is);
                 } catch (IOException e) {
                     e.printStackTrace();
-                    return null;
                 }
             }
         }

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -73,7 +73,7 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
 
     protected Library getLibraryFromElm(VersionedIdentifier libraryIdentifier) {
         org.hl7.elm.r1.VersionedIdentifier versionedIdentifier = toElmIdentifier(libraryIdentifier);
-        for (var type: List.of(LibraryContentType.JSON)) {
+        for (var type: List.of(LibraryContentType.JSON, LibraryContentType.XML)) {
             InputStream is = this.getLibraryContent(versionedIdentifier, type);
             if (is != null) {
                 try {

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -73,7 +73,7 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
 
     protected Library getLibraryFromElm(VersionedIdentifier libraryIdentifier) {
         org.hl7.elm.r1.VersionedIdentifier versionedIdentifier = toElmIdentifier(libraryIdentifier);
-        for (var type: LibraryContentType.values()) {
+        for (var type: List.of(LibraryContentType.JSON)) {
             InputStream is = this.getLibraryContent(versionedIdentifier, type);
             if (is != null) {
                 try {

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -17,19 +17,13 @@ import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.CompiledLibrary;
-import org.cqframework.cql.cql2elm.model.serialization.LibraryWrapper;
 import org.cqframework.cql.elm.execution.Library;
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.opencds.cqf.cql.engine.exception.CqlException;
-import org.opencds.cqf.cql.engine.execution.JsonCqlLibraryReader;
+import org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderFactory;
 import org.opencds.cqf.cql.evaluator.engine.elm.LibraryMapper;
 import org.opencds.cqf.cql.evaluator.engine.util.TranslatorOptionsUtil;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 /**
  * The TranslatingLibraryLoader attempts to load a library from a set of
@@ -42,8 +36,6 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
  * CQL content is found for the requested Library, null is returned.
  */
 public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoader {
-
-    protected static ObjectMapper objectMapper;
 
     protected CqlTranslatorOptions cqlTranslatorOptions;
     protected List<LibrarySourceProvider> librarySourceProviders;
@@ -81,12 +73,15 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
 
     protected Library getLibraryFromElm(VersionedIdentifier libraryIdentifier) {
         org.hl7.elm.r1.VersionedIdentifier versionedIdentifier = toElmIdentifier(libraryIdentifier);
-        InputStream content = this.getLibraryContent(versionedIdentifier, LibraryContentType.JSON);
-        if (content != null) {
-            try {
-                return this.readJxson(content);
-            } catch (Exception e) {
-                // Intentionally empty. Fall through to xml
+        for (var type: LibraryContentType.values()) {
+            InputStream is = this.getLibraryContent(versionedIdentifier, type);
+            if (is != null) {
+                try {
+                    return CqlLibraryReaderFactory.getReader(type.mimeType()).read(is);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return null;
+                }
             }
         }
 
@@ -138,37 +133,6 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
         catch(Exception e) {
             throw new CqlException(String.format("Mapping of library %s failed", libraryIdentifier.getId()), e);
         }
-    }
-
-    protected synchronized Library readJxson(InputStream inputStream) throws IOException {
-        return JsonCqlLibraryReader.read(inputStream);
-    }
-
-    protected synchronized String toJxson(org.hl7.elm.r1.Library library) {
-        try {
-            return convertToJxson(library);
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Could not convert library to JXSON.", e);
-        }
-    }
-
-    protected synchronized ObjectMapper getJxsonMapper() {
-        if (objectMapper == null) {
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
-            mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-            JaxbAnnotationModule annotationModule = new JaxbAnnotationModule();
-            mapper.registerModule(annotationModule);
-            objectMapper = mapper;
-        }
-
-        return objectMapper;
-    }
-
-    public String convertToJxson(org.hl7.elm.r1.Library library) throws JsonProcessingException {
-        LibraryWrapper wrapper = new LibraryWrapper();
-        wrapper.setLibrary(library);
-        return this.getJxsonMapper().writeValueAsString(wrapper);
     }
 
 }

--- a/evaluator/src/test/java/org/opencds/cqf/cql/evaluator/cql2elm/model/CacheAwareModelManagerTests.java
+++ b/evaluator/src/test/java/org/opencds/cqf/cql/evaluator/cql2elm/model/CacheAwareModelManagerTests.java
@@ -10,18 +10,18 @@ import java.util.Map;
 
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.Model;
-import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.testng.annotations.Test;
 
 public class CacheAwareModelManagerTests {
 
     @Test
     public void Multiple_resolutions_should_use_cache(){
-        Map<VersionedIdentifier, Model> cache = new HashMap<VersionedIdentifier, Model>();
-        Map<VersionedIdentifier, Model> cacheSpy = spy(cache);
+        Map<ModelIdentifier, Model> cache = new HashMap<>();
+        Map<ModelIdentifier, Model> cacheSpy = spy(cache);
 
         ModelManager manager = new CacheAwareModelManager(cacheSpy);
-        VersionedIdentifier versionedIdentifier = new VersionedIdentifier().withId("FHIR").withVersion("4.0.0");
+        ModelIdentifier versionedIdentifier = new ModelIdentifier().withId("FHIR").withVersion("4.0.0");
 
         // First resolution should load global cache
         Model result = manager.resolveModel(versionedIdentifier);

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
             </dependency>
 
             <!-- JAXB Implementation -->
-            <!-- This should be used on Test scope only, through evaluator.jaxb-deps -->
+            <!-- This should be used on test scope only, through evaluator.jaxb-deps -->
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.moxy</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,19 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- JAXB Implementation -->
+            <!-- This should be used on Test scope only, through evaluator.jaxb-deps -->
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.moxy</artifactId>
+                <version>2.7.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.json</artifactId>
+                <version>1.0.4</version>
+            </dependency>
+
 
             <!-- Logging -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,38 @@
                 <version>${cql-translator.version}</version>
             </dependency>
             <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>model-jackson</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>elm-jackson</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>model-jaxb</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>elm-jaxb</artifactId>
+                <version>${cql-translator.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.opencds.cqf.cql</groupId>
                 <artifactId>engine.fhir</artifactId>
+                <version>${cql-engine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opencds.cqf.cql</groupId>
+                <artifactId>engine.jaxb</artifactId>
+                <version>${cql-engine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opencds.cqf.cql</groupId>
+                <artifactId>engine.jackson</artifactId>
                 <version>${cql-engine.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
1. Adding the new engine.jackson module to the POM
2. Using Service Loaders in the Translating Library Loader (using only jackson and JSON libs for now)
3. Using our own interceptor for the Rest Client (since we are not using HAPI-FHIR-Client anymore). 
4. Renaming VersionIdentifier to ModelIdentifier (Translator 2.1)
5. Adding javax.json when using Moxy
