### PR TITLE
Formalizes compliance with Android 8, SDK 26 (2017+)

### DIFF
--- a/evaluator.activitydefinition/pom.xml
+++ b/evaluator.activitydefinition/pom.xml
@@ -47,4 +47,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator.activitydefinition/pom.xml
+++ b/evaluator.activitydefinition/pom.xml
@@ -52,14 +52,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.builder/pom.xml
+++ b/evaluator.builder/pom.xml
@@ -33,4 +33,20 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator.builder/pom.xml
+++ b/evaluator.builder/pom.xml
@@ -38,14 +38,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.dagger/pom.xml
+++ b/evaluator.dagger/pom.xml
@@ -59,6 +59,12 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -74,10 +80,6 @@
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/evaluator.dagger/pom.xml
+++ b/evaluator.dagger/pom.xml
@@ -78,14 +78,6 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.22</version>
-                    <configuration>
-                        <signature>
-                            <groupId>net.sf.androidscents.signature</groupId>
-                            <artifactId>android-api-level-26</artifactId>
-                            <version>8.0.0_r2</version>
-                        </signature>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/evaluator.dagger/pom.xml
+++ b/evaluator.dagger/pom.xml
@@ -75,6 +75,18 @@
                         </annotationProcessorPaths>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.22</version>
+                    <configuration>
+                        <signature>
+                            <groupId>net.sf.androidscents.signature</groupId>
+                            <artifactId>android-api-level-26</artifactId>
+                            <version>8.0.0_r2</version>
+                        </signature>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/evaluator.expression/pom.xml
+++ b/evaluator.expression/pom.xml
@@ -45,4 +45,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator.expression/pom.xml
+++ b/evaluator.expression/pom.xml
@@ -51,14 +51,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.fhir/pom.xml
+++ b/evaluator.fhir/pom.xml
@@ -69,6 +69,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
             <!-- <plugin>
                 <groupId>org.fugerit.java</groupId>
                 <artifactId>freemarker-maven-plugin</artifactId>

--- a/evaluator.fhir/pom.xml
+++ b/evaluator.fhir/pom.xml
@@ -72,14 +72,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
             <!-- <plugin>
                 <groupId>org.fugerit.java</groupId>

--- a/evaluator.library/pom.xml
+++ b/evaluator.library/pom.xml
@@ -47,14 +47,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.library/pom.xml
+++ b/evaluator.library/pom.xml
@@ -41,4 +41,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator.measure-hapi/pom.xml
+++ b/evaluator.measure-hapi/pom.xml
@@ -51,4 +51,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator.measure-hapi/pom.xml
+++ b/evaluator.measure-hapi/pom.xml
@@ -57,14 +57,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.measure/pom.xml
+++ b/evaluator.measure/pom.xml
@@ -29,14 +29,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.measure/pom.xml
+++ b/evaluator.measure/pom.xml
@@ -23,4 +23,21 @@
             <version>2.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator.plandefinition/pom.xml
+++ b/evaluator.plandefinition/pom.xml
@@ -63,14 +63,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator.plandefinition/pom.xml
+++ b/evaluator.plandefinition/pom.xml
@@ -57,4 +57,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/evaluator/pom.xml
+++ b/evaluator/pom.xml
@@ -125,6 +125,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.22</version>
+                <configuration>
+                    <signature>
+                        <groupId>net.sf.androidscents.signature</groupId>
+                        <artifactId>android-api-level-26</artifactId>
+                        <version>8.0.0_r2</version>
+                    </signature>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/evaluator/pom.xml
+++ b/evaluator/pom.xml
@@ -128,14 +128,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.22</version>
-                <configuration>
-                    <signature>
-                        <groupId>net.sf.androidscents.signature</groupId>
-                        <artifactId>android-api-level-26</artifactId>
-                        <version>8.0.0_r2</version>
-                    </signature>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -73,7 +73,7 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
 
     protected Library getLibraryFromElm(VersionedIdentifier libraryIdentifier) {
         org.hl7.elm.r1.VersionedIdentifier versionedIdentifier = toElmIdentifier(libraryIdentifier);
-        for (var type: List.of(LibraryContentType.JSON, LibraryContentType.XML)) {
+        for (var type: new LibraryContentType[]{LibraryContentType.JSON, LibraryContentType.XML}) {
             InputStream is = this.getLibraryContent(versionedIdentifier, type);
             if (is != null) {
                 try {

--- a/pom.xml
+++ b/pom.xml
@@ -568,6 +568,27 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.22</version>
+                    <configuration>
+                        <signature>
+                            <groupId>net.sf.androidscents.signature</groupId>
+                            <artifactId>android-api-level-26</artifactId>
+                            <version>8.0.0_r2</version>
+                        </signature>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-android-26-compliance</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
This PR formalizes this project's compliance with Android APIs
1. Adds an Animal Sniffer plugin to check compliance with any runtime API when running `mvn test`
2. Selects modules `evaluator`, `evaluator.activitydefinition`, `evaluator.builder`, `evaluator.dagger`, `evaluator.expression`, `evaluator.fhir`, `evaluator.library`, `evaluator.measure`, `evaluator.measure-hapi`, `evaluator.plandefinition` to be checked for Android compliance. 
3. Establishes initial compliance to Android 8 - SDK 26, the minimum Android version the Translator is currently fully compliant with. 

**Important**: The plugin only verifies the source code in this project, not dependencies. 

For testing, add: 

```java
if (Optional.of(UUID.randomUUID()).isEmpty())
   throw new RuntimeException("Test");
```

in the desired module and run `mvn animal-sniffer:check`. 

Since the method `Optional.isEmpty` is not available on Android, the output should look like this: 

```
[INFO] --- animal-sniffer-maven-plugin:1.22:check (check-android-26-compliance) @ evaluator.builder ---
[INFO] Checking unresolved references to net.sf.androidscents.signature:android-api-level-26:8.0.0_r2
[ERROR] /Users/vitor/Documents/workspace/cql-evaluator/evaluator.builder/src/main/java/org/opencds/cqf/cql/evaluator/builder/CqlEvaluatorBuilder.java:152: Undefined reference: boolean java.util.Optional.isEmpty()
```


