### PR TITLE
remove redundant execution

### DIFF
--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -57,6 +57,12 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
     }
 
     public Library load(VersionedIdentifier libraryIdentifier) {
+        Library library = this.getLibraryFromElm(libraryIdentifier);
+
+        if (library != null && this.translatorOptionsMatch(library)) {
+            return library;
+        }
+        this.cqlTranslatorOptions.setEnableCqlOnly(true);
         return this.translate(libraryIdentifier);
     }
 

--- a/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
+++ b/evaluator/src/main/java/org/opencds/cqf/cql/evaluator/engine/execution/TranslatingLibraryLoader.java
@@ -57,12 +57,6 @@ public class TranslatingLibraryLoader implements TranslatorOptionAwareLibraryLoa
     }
 
     public Library load(VersionedIdentifier libraryIdentifier) {
-        Library library = this.getLibraryFromElm(libraryIdentifier);
-
-        if (library != null && this.translatorOptionsMatch(library)) {
-            return library;
-        }
-
         return this.translate(libraryIdentifier);
     }
 


### PR DESCRIPTION
this section is repetitive in libraryManager.resolveLibrary()
use setting enableCqlOnly to true to remove redundancy