### PR TITLE
Fix resource type resolution from contained resources

### DIFF
--- a/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
+++ b/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Goal;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.r4.model.ParameterDefinition;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
@@ -282,7 +283,7 @@ public class PlanDefinitionProcessor {
     if (action.hasDefinitionCanonicalType()) {
       logger.debug("Resolving definition " + action.getDefinitionCanonicalType().getValue());
       var definition = action.getDefinitionCanonicalType();
-      var resourceName = getResourceName(definition);
+      var resourceName = resolveResourceName(definition, planDefinition);
       switch (resourceName) {
         case "PlanDefinition":
           applyNestedPlanDefinition(requestGroup, session, definition, action);
@@ -640,12 +641,15 @@ public class PlanDefinitionProcessor {
   // return ((StringType) result).asStringValue();
   // }
 
-  protected static String getResourceName(CanonicalType canonical) {
+  protected String resolveResourceName(CanonicalType canonical, MetadataResource resource) {
     if (canonical.hasValue()) {
       var id = canonical.getValue();
       if (id.contains("/")) {
         id = id.replace(id.substring(id.lastIndexOf("/")), "");
         return id.contains("/") ? id.substring(id.lastIndexOf("/") + 1) : id;
+      }
+      else if (id.startsWith("#")){
+        return resolveContained(resource, id).getResourceType().name();
       }
       return null;
     }

--- a/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
+++ b/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
@@ -284,7 +284,6 @@ public class PlanDefinitionProcessor {
     if (action.hasDefinitionCanonicalType()) {
       logger.debug("Resolving definition {}", action.getDefinitionCanonicalType().getValue());
       var definition = action.getDefinitionCanonicalType();
-      switch (resourceName) {
       var resourceName = resolveResourceName(definition, planDefinition);
       switch (requireNonNull(resourceName)) {
         case "PlanDefinition":

--- a/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessorTests.java
+++ b/evaluator.plandefinition/src/test/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessorTests.java
@@ -26,6 +26,28 @@ public class PlanDefinitionProcessorTests extends PlanDefinition {
     }
 
     @Test
+    public void testAncVisitContainedActivityDefinition() {
+        PlanDefinition.Assert.that(
+                "AncVisit-PlanDefinition",
+                "Patient/TEST_PATIENT",
+                null
+            )
+            .withData("anc-visit/anc_visit_patient.json")
+            .withLibrary("anc-visit/anc_visit_plan_definition.json")
+            .apply()
+            .isEqualsTo("anc-visit/anc_visit_careplan.json");
+        PlanDefinition.Assert.that(
+                "AncVisit-PlanDefinition",
+                "Patient/TEST_PATIENT",
+                null
+            )
+            .withData("anc-visit/anc_visit_patient.json")
+            .withLibrary("anc-visit/anc_visit_plan_definition.json")
+            .applyR5()
+            .isEqualsTo("anc-visit/anc_visit_bundle.json");
+    }
+
+    @Test
     public void testHelloWorld() {
         PlanDefinition.Assert.that(
                 "hello-world-patient-view",

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_bundle.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_bundle.json
@@ -1,0 +1,99 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "RequestGroup",
+        "id": "AncVisit-PlanDefinition",
+        "extension": [
+          {
+            "url": "http://fl7.org/fhir/StructureDefinition/RequestGroup-Goal",
+            "valueReference": {
+              "reference": "Goal/1"
+            }
+          }
+        ],
+        "instantiatesCanonical": [
+          "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/AncVisit-PlanDefinition"
+        ],
+        "status": "draft",
+        "intent": "proposal",
+        "subject": {
+          "reference": "Patient/TEST_PATIENT"
+        },
+        "action": [
+          {
+            "resource": {
+              "reference": "Task"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Goal",
+        "id": "1",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "https://www.hl7.org/fhir/codesystem-goal-category.html",
+                "code": "nursing",
+                "display": "Nursing"
+              }
+            ]
+          }
+        ],
+        "priority": {
+          "coding": [
+            {
+              "system": "https://www.hl7.org/fhir/codesystem-goal-priority.html",
+              "code": "high-priority",
+              "display": "High Priority"
+            }
+          ]
+        },
+        "startCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.snomed.org/",
+              "code": "32485007",
+              "display": "Admission to hospital"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Task",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/targetStatus",
+            "valueString": "ready"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "RequestGroup/AncVisit-PlanDefinition",
+            "type": "RequestGroup"
+          }
+        ],
+        "status": "ready",
+        "code": {
+          "coding": [
+            {
+              "system": "http://example.org/CodeSystem/encounter-type",
+              "code": "pregnant_monthly_visit",
+              "display": "Pregnant (ANC) Monthly Routine visit"
+            }
+          ],
+          "text": "Pregnant (ANC) Monthly Routine visit"
+        },
+        "description": "This action will performed every month for a pregnant woman"
+      }
+    }
+  ]
+}

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_careplan.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_careplan.json
@@ -1,0 +1,77 @@
+{
+  "resourceType": "CarePlan",
+  "contained": [ {
+    "resourceType": "RequestGroup",
+    "id": "AncVisit-PlanDefinition",
+    "instantiatesCanonical": [ "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/AncVisit-PlanDefinition" ],
+    "status": "draft",
+    "intent": "proposal",
+    "subject": {
+      "reference": "Patient/TEST_PATIENT"
+    },
+    "action": [ {
+      "resource": {
+        "reference": "Task"
+      }
+    } ]
+  }, {
+    "resourceType": "Goal",
+    "id": "1",
+    "category": [ {
+      "coding": [ {
+        "system": "https://www.hl7.org/fhir/codesystem-goal-category.html",
+        "code": "nursing",
+        "display": "Nursing"
+      } ]
+    } ],
+    "priority": {
+      "coding": [ {
+        "system": "https://www.hl7.org/fhir/codesystem-goal-priority.html",
+        "code": "high-priority",
+        "display": "High Priority"
+      } ]
+    },
+    "startCodeableConcept": {
+      "coding": [ {
+        "system": "http://www.snomed.org/",
+        "code": "32485007",
+        "display": "Admission to hospital"
+      } ]
+    }
+  }, {
+    "resourceType": "Task",
+    "id": "Task",
+    "extension": [ {
+      "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/targetStatus",
+      "valueString": "ready"
+    } ],
+    "basedOn": [ {
+      "reference": "#RequestGroup/AncVisit-PlanDefinition",
+      "type": "RequestGroup"
+    } ],
+    "status": "ready",
+    "code": {
+      "coding": [ {
+        "system": "http://example.org/CodeSystem/encounter-type",
+        "code": "pregnant_monthly_visit",
+        "display": "Pregnant (ANC) Monthly Routine visit"
+      } ],
+      "text": "Pregnant (ANC) Monthly Routine visit"
+    },
+    "description": "This action will performed every month for a pregnant woman"
+  } ],
+  "instantiatesCanonical": [ "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/AncVisit-PlanDefinition" ],
+  "status": "draft",
+  "intent": "proposal",
+  "subject": {
+    "reference": "Patient/TEST_PATIENT"
+  },
+  "goal": [ {
+    "reference": "#1"
+  } ],
+  "activity": [ {
+    "reference": {
+      "reference": "#AncVisit-PlanDefinition"
+    }
+  } ]
+}

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_patient.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_patient.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "Bundle",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "Patient/TEST_PATIENT",
+        "active": true,
+        "name": [
+          {
+            "family": "Hadi",
+            "given": [
+              "Bareera"
+            ]
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1999-01-14",
+        "generalPractitioner": [
+          {
+            "reference": "Practitioner/TEST_PRACTITIONER"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_plan_definition.json
+++ b/evaluator.plandefinition/src/test/resources/org/opencds/cqf/cql/evaluator/plandefinition/r4/anc-visit/anc_visit_plan_definition.json
@@ -1,0 +1,110 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "PlanDefinition",
+        "id": "AncVisit-PlanDefinition",
+        "url": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/AncVisit-PlanDefinition",
+        "contained": [
+          {
+            "resourceType": "ActivityDefinition",
+            "id": "careplan-activity",
+            "url": "ActivityDefinition/careplan-activity",
+            "title": "ANC Follow Up Plan",
+            "status": "active",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://example.org/CodeSystem/encounter-type",
+                  "code": "pregnant_monthly_visit",
+                  "display": "Pregnant (ANC) Monthly Routine visit"
+                }
+              ],
+              "text": "Pregnant (ANC) Monthly Routine visit"
+            },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/ecr/StructureDefinition/targetStatus",
+                "valueString": "ready"
+              }
+            ],
+            "description": "This action will performed every month for a pregnant woman",
+            "kind": "Task",
+            "timingTiming": {
+              "repeat": {
+                "countMax": 8,
+                "duration": 2,
+                "durationMax": 4,
+                "durationUnit": "h",
+                "frequency": 1,
+                "frequencyMax": 1,
+                "period": 1,
+                "periodMax": 1,
+                "periodUnit": "mo"
+              }
+            }
+          }
+        ],
+        "name": "ANC Follow Up Plan",
+        "title": "ANC Follow Up Plan",
+        "status": "active",
+        "description": "This defines the schedule of care for pregnant women",
+        "goal": [
+          {
+            "category": {
+              "coding": [
+                {
+                  "system": "https://www.hl7.org/fhir/codesystem-goal-category.html",
+                  "code": "nursing",
+                  "display": "Nursing"
+                }
+              ]
+            },
+            "priority": {
+              "coding": [
+                {
+                  "system": "https://www.hl7.org/fhir/codesystem-goal-priority.html",
+                  "code": "high-priority",
+                  "display": "High Priority"
+                }
+              ]
+            },
+            "start": {
+              "coding": [
+                {
+                  "system": "http://www.snomed.org/",
+                  "code": "32485007",
+                  "display": "Admission to hospital"
+                }
+              ]
+            }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "code": "clinical-protocol",
+              "system": "http://hl7.org/fhir/ValueSet/plan-definition-type"
+            }
+          ]
+        },
+        "action": [
+          {
+            "priority": "routine",
+            "type": {
+              "coding": [
+                {
+                  "code": "clinical-protocol",
+                  "display": "Clinical Protocol"
+                }
+              ]
+            },
+            "definitionCanonical": "#careplan-activity"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The fhir-path specs allows to use [contained resources into plan-definition](https://hl7.org/fhir/R4/plandefinition-example.json.html) for better organization of dependent resources like ActivityDefinition. This is especially helpful and clean when using multiple ActivityDefinitions for a PlanDefinition. The current code despite allowing and parsing the local-ids (at L355) in method applyActivityDefinition does not work with local contained resources and fails before due to not being able to parse resource name