### PR TITLE
Fixes for downstream CDSHooks update 

### DIFF
--- a/evaluator.library/src/main/java/org/opencds/cqf/cql/evaluator/library/LibraryProcessor.java
+++ b/evaluator.library/src/main/java/org/opencds/cqf/cql/evaluator/library/LibraryProcessor.java
@@ -27,12 +27,14 @@ import org.opencds.cqf.cql.evaluator.builder.ModelResolverFactory;
 import org.opencds.cqf.cql.evaluator.builder.TerminologyProviderFactory;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+@SuppressWarnings({"unused", "squid:S107"})
 @Named
 public class LibraryProcessor {
 
-    // private static Logger logger =
-    // LoggerFactory.getLogger(LibraryProcessor.class);
+    private static final Logger logger = LoggerFactory.getLogger(LibraryProcessor.class);
 
     protected FhirContext fhirContext;
     protected CqlFhirParametersConverter cqlFhirParametersConverter;
@@ -152,7 +154,10 @@ public class LibraryProcessor {
 
         Pair<String, Object> contextParameter = null;
         if (patientId != null) {
-            contextParameter = Pair.of("Patient", (Object) patientId);
+            if (patientId.startsWith("Patient/")) {
+                patientId = patientId.replace("Patient/", "");
+            }
+            contextParameter = Pair.of("Patient", patientId);
         }
 
         return libraryEvaluator.evaluate(id, contextParameter, parameters, expressions);
@@ -217,7 +222,6 @@ public class LibraryProcessor {
             throw new IllegalArgumentException("Invalid url, Library.url SHALL be <CQL namespace url>/Library/<CQL library name>");
         }
 
-        @SuppressWarnings("unused")
         String cqlNamespaceUrl = urlSplit[0];
 
         String cqlName = urlSplit[1];

--- a/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
+++ b/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
@@ -57,6 +57,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.fhirpath.FhirPathExecutionException;
 import ca.uhn.fhir.fhirpath.IFhirPath;
 
+@SuppressWarnings("squid:S107")
 public class PlanDefinitionProcessor {
   protected ActivityDefinitionProcessor activityDefinitionProcessor;
   protected LibraryProcessor libraryProcessor;
@@ -162,7 +163,7 @@ public class PlanDefinitionProcessor {
     var planDefinition = castOrThrow(basePlanDefinition, PlanDefinition.class,
         "The planDefinition passed to FhirDal was not a valid instance of PlanDefinition.class").get();
 
-    logger.info("Performing $apply operation on PlanDefinition/" + theId);
+    logger.info("Performing $apply operation on PlanDefinition/{}", theId);
 
     return planDefinition;
   }
@@ -280,10 +281,10 @@ public class PlanDefinitionProcessor {
   private void resolveDefinition(PlanDefinition planDefinition, RequestGroup requestGroup, Session session,
       PlanDefinition.PlanDefinitionActionComponent action) {
     if (action.hasDefinitionCanonicalType()) {
-      logger.debug("Resolving definition " + action.getDefinitionCanonicalType().getValue());
+      logger.debug("Resolving definition {}", action.getDefinitionCanonicalType().getValue());
       var definition = action.getDefinitionCanonicalType();
       var resourceName = getResourceName(definition);
-      switch (resourceName) {
+      switch (requireNonNull(resourceName)) {
         case "PlanDefinition":
           applyNestedPlanDefinition(requestGroup, session, definition, action);
           break;
@@ -294,7 +295,7 @@ public class PlanDefinitionProcessor {
           applyQuestionnaireDefinition(planDefinition, requestGroup, session, definition, action);
           break;
         default:
-          throw new RuntimeException(String.format("Unknown action definition: ", definition));
+          throw new RuntimeException(String.format("Unknown action definition: %s", definition));
       }
     } else if (action.hasDefinitionUriType()) {
       var definition = action.getDefinitionUriType();
@@ -594,7 +595,7 @@ public class PlanDefinitionProcessor {
         }
 
         if (!(result instanceof BooleanType)) {
-          logger.warn("The condition returned a non-boolean value: " + result.getClass().getSimpleName());
+          logger.warn("The condition returned a non-boolean value: {}", result.getClass().getSimpleName());
           continue;
         }
 
@@ -612,7 +613,7 @@ public class PlanDefinitionProcessor {
     if (expression.hasReference()) {
       return expression.getReference();
     }
-    logger.warn(String.format("No library reference for expression: %s", expression.getExpression()));
+    logger.warn("No library reference for expression: {}", expression.getExpression());
     if (planDefinition.getLibrary().size() == 1) {
       return planDefinition.getLibrary().get(0).asStringValue();
     }
@@ -655,7 +656,8 @@ public class PlanDefinitionProcessor {
 
   public Object getParameterComponentByName(Parameters params, String name) {
     var first = params.getParameter().stream().filter(x -> x.getName().equals(name)).findFirst();
-    var component = first.isPresent() ? first.get() : null;
+    var component = first.orElse(null);
+    if (component == null) return null;
     return component.hasValue() ? component.getValue() : component.getResource();
   }
 
@@ -663,7 +665,7 @@ public class PlanDefinitionProcessor {
   protected Object evaluateConditionOrDynamicValue(String expression, String language, String libraryToBeEvaluated,
       Session session, List<DataRequirement> dataRequirements) {
     var params = resolveInputParameters(dataRequirements);
-    if (session.parameters != null && session.parameters instanceof Parameters) {
+    if (session.parameters instanceof Parameters) {
       params.getParameter().addAll(((Parameters) session.parameters).getParameter());
     }
 
@@ -673,6 +675,8 @@ public class PlanDefinitionProcessor {
       case "text/cql.expression":
       case "text/cql-expression":
         result = expressionEvaluator.evaluate(expression, params);
+        // The expression is assumed to be the parameter component name used in getParameterComponentByName()
+        expression = "return";
         break;
       case "text/cql-identifier":
       case "text/cql.identifier":
@@ -689,9 +693,7 @@ public class PlanDefinitionProcessor {
         } catch (FhirPathExecutionException e) {
           throw new IllegalArgumentException("Error evaluating FHIRPath expression", e);
         }
-        if (outputs == null || outputs.isEmpty()) {
-          result = null;
-        } else if (outputs.size() == 1) {
+        if (outputs != null && outputs.size() == 1) {
           result = outputs.get(0);
         } else {
           throw new IllegalArgumentException(
@@ -699,7 +701,7 @@ public class PlanDefinitionProcessor {
         }
         break;
       default:
-        logger.warn("An action language other than CQL was found: " + language);
+        logger.warn("An action language other than CQL was found: {}", language);
     }
     if (result instanceof Parameters) {
       result = getParameterComponentByName((Parameters) result, expression);
@@ -715,7 +717,7 @@ public class PlanDefinitionProcessor {
     for (var req : dataRequirements) {
       var resources = fhirDal.search(req.getType()).iterator();
 
-      if (resources != null && resources.hasNext()) {
+      if (resources.hasNext()) {
         var index = 0;
         var found = true;
         while (resources.hasNext()) {
@@ -731,15 +733,15 @@ public class PlanDefinitionProcessor {
                   codeFilterParam.addParameter().setName("%valueset")
                       .setResource((Resource) valueset.iterator().next());
                   var codeFilterExpression = "%"
-                      + String.format("resource.%s.where(code.memberOf(\'%s\'))", filter.getPath(), "%" + "valueset");
+                      + String.format("resource.%s.where(code.memberOf('%s'))", filter.getPath(), "%" + "valueset");
                   var codeFilterResult = expressionEvaluator.evaluate(codeFilterExpression, codeFilterParam);
-                  var tempResult = operationParametersParser.getValueChild(((Parameters) codeFilterResult), "return");
+                  var tempResult = operationParametersParser.getValueChild((codeFilterResult), "return");
                   if (tempResult instanceof BooleanType) {
                     found = ((BooleanType) tempResult).booleanValue();
                   }
                 }
                 logger.debug(
-                    String.format("Could not find ValueSet with url %s on the local server.", filter.getValueSet()));
+                    "Could not find ValueSet with url {} on the local server.", filter.getValueSet());
               }
             }
           }
@@ -771,9 +773,9 @@ public class PlanDefinitionProcessor {
 
   protected Resource resolveContained(DomainResource resource, String id) {
     var first = resource.getContained().stream()
-        .filter(x -> x.hasIdElement())
+        .filter(Resource::hasIdElement)
         .filter(x -> x.getIdElement().getIdPart().equals(id))
         .findFirst();
-    return first.isPresent() ? first.get() : null;
+    return first.orElse(null);
   }
 }

--- a/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
+++ b/evaluator.plandefinition/src/main/java/org/opencds/cqf/cql/evaluator/plandefinition/r4/PlanDefinitionProcessor.java
@@ -57,7 +57,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.fhirpath.FhirPathExecutionException;
 import ca.uhn.fhir.fhirpath.IFhirPath;
 
-@SuppressWarnings("squid:S107")
+@SuppressWarnings({"unused", "squid:S107"})
 public class PlanDefinitionProcessor {
   protected ActivityDefinitionProcessor activityDefinitionProcessor;
   protected LibraryProcessor libraryProcessor;
@@ -261,7 +261,7 @@ public class PlanDefinitionProcessor {
       Map<String, PlanDefinition.PlanDefinitionActionComponent> metConditions,
       PlanDefinition.PlanDefinitionActionComponent action) {
     // TODO: If action has inputs generate QuestionnaireItems
-    if (meetsConditions(planDefinition, requestGroup, session, action)) {
+    if (Boolean.TRUE.equals(meetsConditions(planDefinition, requestGroup, session, action))) {
       if (action.hasRelatedAction()) {
         for (var relatedActionComponent : action.getRelatedAction()) {
           if (relatedActionComponent.getRelationship().equals(ActionRelationshipType.AFTER)


### PR DESCRIPTION
Fixes to enable resolution for https://github.com/DBCG/cqf-ruler/issues/539
Fixes issue with LibraryProcessor not accounting for reference-styled patient IDs (e.g. Patient/example-patient)
Fixes issue with PlanDefinitionProcessor not resolving expression evaluation correctly - assumes the expression will be an identifier
Also cleaned up a bunch of warnings